### PR TITLE
fix: correct typos in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Cloudinary and GitHub variables are only needed if you're touching uploads or pr
 ## Branching
 
 - Branch off `main` for every change.
-- Use a discriptive branch name with a type prefix:
+- Use a descriptive branch name with a type prefix:
   - `feat/<short-description>` for new features
   - `fix/<short-description>` for bug fixes
   - `docs/<short-description>` for documentation
@@ -51,7 +51,7 @@ Cloudinary and GitHub variables are only needed if you're touching uploads or pr
 
 ## Commit messages
 
-We use [Convential Commits](https://www.conventionalcommits.org/). The first line should be:
+We use [Conventional Commits](https://www.conventionalcommits.org/). The first line should be:
 
 ```
 <type>: <short summary>
@@ -65,7 +65,7 @@ Examples from this repo:
 - `fix: simplify error handling in middleware`
 - `docs: document admin API key flow`
 
-Keep the summary under 72 charecters. Add a longer body if the change needs context.
+Keep the summary under 72 characters. Add a longer body if the change needs context.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Backend for the official website of [Open Source Kigali](https://github.com/Open-Source-Kigali).
 
-Build with Express, TypeScript, Prisma, and PostgreSQL.
+Built with Express, TypeScript, Prisma, and PostgreSQL.
 
 ## Tech stack
 
@@ -10,7 +10,7 @@ Build with Express, TypeScript, Prisma, and PostgreSQL.
 - **Language:** TypeScript (strict mode)
 - **Database:** PostgreSQL via Prisma
 - **Image storage:** Cloudinary
-- **API docs:** OpenAPI served trough Swagger UI
+- **API docs:** OpenAPI served through Swagger UI
 
 ## Getting started
 
@@ -80,7 +80,7 @@ To stop the database: `docker compose down` (add `-v` to wipe the data).
 
 ## API documentation
 
-Interractive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
+Interactive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 


### PR DESCRIPTION
## Summary
Corrected 6 typos across README.md and CONTRIBUTING.md:

### README.md
- Line 5: `Build` → `Built`
- Line 13: `trough` → `through`
- Line 83: `Interractive` → `Interactive`

### CONTRIBUTING.md
- Line 45: `discriptive` → `descriptive`
- Line 54: `Convential` → `Conventional`
- Line 68: `charecters` → `characters`

## Fixes
Fixes #36, #38, #39, #40, #42, #43