### PR TITLE
docs: fix typos in README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ We use a three-branch flow: `dev` → `staging` → `main`.
 - **Always branch off `dev`** — it is the default branch and the target for all contributor PRs.
 - `staging` is periodically merged from `dev` for pre-production testing.
 - `main` is production — only merged from `staging` when ready to ship.
-- Use a discriptive branch name with a type prefix:
+- Use a descriptive branch name with a type prefix:
   - `feat/<short-description>` for new features
   - `fix/<short-description>` for bug fixes
   - `docs/<short-description>` for documentation
@@ -55,7 +55,7 @@ We use a three-branch flow: `dev` → `staging` → `main`.
 
 ## Commit messages
 
-We use [Convential Commits](https://www.conventionalcommits.org/). The first line should be:
+We use [Conventional Commits](https://www.conventionalcommits.org/). The first line should be:
 
 ```
 <type>: <short summary>
@@ -69,7 +69,7 @@ Examples from this repo:
 - `fix: simplify error handling in middleware`
 - `docs: document admin API key flow`
 
-Keep the summary under 72 charecters. Add a longer body if the change needs context.
+Keep the summary under 72 characters. Add a longer body if the change needs context.
 
 ## Code style
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Backend for the official website of [Open Source Kigali](https://github.com/Open-Source-Kigali).
 
-Build with Express, TypeScript, Prisma, and PostgreSQL.
+Built with Express, TypeScript, Prisma, and PostgreSQL.
 
 ## Tech stack
 
@@ -10,7 +10,7 @@ Build with Express, TypeScript, Prisma, and PostgreSQL.
 - **Language:** TypeScript (strict mode)
 - **Database:** PostgreSQL via Prisma
 - **Image storage:** Cloudinary
-- **API docs:** OpenAPI served trough Swagger UI
+- **API docs:** OpenAPI served through Swagger UI
 
 ## Getting started
 
@@ -80,7 +80,7 @@ To stop the database: `docker compose down` (add `-v` to wipe the data).
 
 ## API documentation
 
-Interractive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
+Interactive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 


### PR DESCRIPTION
## Summary
Fixes #36, #38, #39, #40, #42, #43 — batch fix for all open documentation typos.

## Root Cause
The README.md and CONTRIBUTING.md files contain several spelling errors that reduce professionalism and readability.

## Solution
Fixed all 6 reported typos across 2 files:

**README.md:**
- `trough` → `through` (#38) 
- `Interractive` → `Interactive` (#39)
- `Build with` → `Built with` (#36)

**CONTRIBUTING.md:**
- `Convential` → `Conventional` (#40)
- `charecters` → `characters` (#42)
- `discriptive` → `descriptive` (#43)

## Changes
- `README.md`: 3 typo fixes (+3 -3)
- `CONTRIBUTING.md`: 3 typo fixes (+3 -3)

## Testing
- ✅ All fixes are one-word spelling corrections with no semantic change
- ✅ Files remain valid Markdown after changes
- ✅ No code or configuration files affected