### PR TITLE
docs: fix OpenAPI typos

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3,7 +3,7 @@ info:
   title: oskbackend API
   version: 1.0.0
   description: |
-    Backned API for Open Source Kigali.
+    Backend API for Open Source Kigali.
 
     All responses follow a consistent envelope:
       Success: `{ "success": true, "message": string, "data": T }`
@@ -43,7 +43,7 @@ paths:
   /members:
     get:
       tags: [Members]
-      summary: List all memebers
+      summary: List all members
       responses:
         "200":
           description: Members retrieved successfully
@@ -253,7 +253,7 @@ paths:
   /partners:
     get:
       tags: [Partners]
-      summary: List all patners
+      summary: List all partners
       responses:
         "200":
           description: Partners retrieved successfully
@@ -402,7 +402,7 @@ paths:
   /projects/refresh:
     post:
       tags: [Projects]
-      summary: Refresh GitHub-cached filds for all projects (admin only)
+      summary: Refresh GitHub-cached fields for all projects (admin only)
       security:
         - adminApiKey: []
       responses:


### PR DESCRIPTION
<!-- hermes-auto-maintainer -->

## Summary
- Fix four OpenAPI documentation typos reported in #44, #45, #46, and #47.
- Correct Backend, fields, members, and partners wording in docs/openapi.yaml.

Fixes #44
Fixes #45
Fixes #46
Fixes #47

## Test plan
- Static validation: verified each reported misspelling appeared exactly once before replacement.
- Static validation: verified the old misspellings no longer appear in docs/openapi.yaml after the patch.
- Not run: runtime test suite, because this is a documentation-only typo fix.
