### PR TITLE
PR: Fixing Typing error in osk-backend/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The server runs on `http://localhost:3000` by default.
 
 ## Scripts
 
-- `npm run dev` - start the server in wacth mode
+- `npm run dev` - start the server in watch mode
 - `npm run build` - compile TypeScript to `dist/`
 - `npm start` - run the compiled build
 
@@ -80,7 +80,7 @@ To stop the database: `docker compose down` (add `-v` to wipe the data).
 
 ## API documentation
 
-Interractive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
+Interactive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 


### PR DESCRIPTION
**doc(`README.md`): fixing typing errors**
- fix typo error on line 29 from `wacth` to its correct version`watch`
- fix typo error on line 83 from ``Interractive to its correct version `Interactive`
