### PR TITLE
Fix/admin api key startup warning

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,12 @@
 import app from "./app";
 import { env } from "./config/env";
-
+if (!env.adminApiKey) {
+  console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
+}
+// if (!env.adminApiKey) {
+//   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
+//   process.exit(1)
+// }
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,12 @@
 import app from "./app";
 import { env } from "./config/env";
-// if (!env.adminApiKey) {
-//   console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
-// }
 if (!env.adminApiKey) {
-  console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
-  process.exit(1)
-} //stops at startup sith error
+  console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
+}
+// if (!env.adminApiKey) {
+//   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
+//   process.exit(1)
+// } 
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@ import { env } from "./config/env";
 if (!env.adminApiKey) {
   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
   process.exit(1)
-}
+} //stops at startup sith error
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,12 @@
 import app from "./app";
 import { env } from "./config/env";
-if (!env.adminApiKey) {
-  console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
-}
 // if (!env.adminApiKey) {
-//   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
-//   process.exit(1)
+//   console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
 // }
+if (!env.adminApiKey) {
+  console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
+  process.exit(1)
+}
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
it Fixes admin api key startup warning

<!-- 1-2 sentences describing your change. -->
i added an if statement that ends with "process.exit(1)" for it to exit with error.
Rather than failing at request time, the app refuses to start at startup when the key is missing

## Related issue

Closes #30 

## How did you test it?
I ran npm run build to check if any damage was made from my change

## Checklist

- [x] My code builds (`npm run build`) I ran npm run build to check if any damage was made from my change
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
