### PR TITLE
fix: add featured filter to events and projects API endpoints

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-<!-- Thanks for contributing! Keep PRs small and focused. -->
-
-## What does this PR do?
-
 <!-- 1-2 sentences describing your change. -->
 
 ## Related issue

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          npm-version: 11.15.0
           cache: npm
 
       - name: Install dependencies

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -513,7 +513,7 @@ paths:
   /contributors:
     get:
       tags: [Contributors]
-      summary: Read and return contributors.json
+      summary: List contributor profiles
       responses:
         "200":
           description: Contributors retrieved successfully
@@ -527,25 +527,18 @@ paths:
                       data:
                         type: array
                         items:
-                          type: object
-                          properties:
-                            login: { type: string }
-                            name: { type: string }
-                            avatarUrl: { type: string }
-                            profileUrl: { type: string }
-                            bio: { type: string }
-                            company: { type: string }
+                          { $ref: "#/components/schemas/ContributorProfile" }
         "500": { $ref: "#/components/responses/InternalError" }
 
   /contributors/refresh:
     post:
       tags: [Contributors]
-      summary: Parse CONTRIBUTORS.md, fetch all GitHub profiles, overwrite contributors.json
+      summary: Refresh contributor profiles from CONTRIBUTORS.md
       security:
         - adminApiKey: []
       responses:
         "200":
-          description: Contributors refreshed successfully
+          description: Contributors refresh completed successfully
           content:
             application/json:
               schema:
@@ -562,10 +555,9 @@ paths:
                           failedList:
                             type: array
                             items:
-                              type: object
-                              properties:
-                                login: { type: string }
-                                error: { type: string }
+                              {
+                                $ref: "#/components/schemas/ContributorRefreshError",
+                              }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "500": { $ref: "#/components/responses/InternalError" }
@@ -672,7 +664,6 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
-
 components:
   securitySchemes:
     adminApiKey:
@@ -688,6 +679,35 @@ components:
         message: { type: string }
         data: {}
       required: [success, message, data]
+
+    ContributorProfile:
+      type: object
+      properties:
+        login: { type: string }
+        name: { type: string, nullable: true }
+        avatarUrl: { type: string, format: uri }
+        profileUrl: { type: string, format: uri }
+        bio: { type: string, nullable: true }
+        company: { type: string, nullable: true }
+      required: [login, avatarUrl, profileUrl]
+
+    ContributorRefreshResult:
+      type: object
+      properties:
+        totalParsed: { type: number }
+        success: { type: number }
+        failures: { type: number }
+        failedList:
+          type: array
+          items: { $ref: "#/components/schemas/ContributorRefreshError" }
+      required: [totalParsed, success, failures, failedList]
+
+    ContributorRefreshError:
+      type: object
+      properties:
+        login: { type: string }
+        error: { type: string }
+      required: [login, error]
 
     ApiError:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1412,9 +1412,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,4 +127,3 @@ model Project {
 
   @@unique([repoOwner, repoName])
 }
-

--- a/src/controllers/contributors.controller.test.ts
+++ b/src/controllers/contributors.controller.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+
+// Ensure admin key is set before app import so middleware reads it
+process.env.ADMIN_API_KEY = "test-admin-key";
+
+import app from "../app";
+
+vi.mock("../services/contributors.service");
+import * as contributorsService from "../services/contributors.service";
+
+const mockContributor = {
+  login: "ub-victor",
+  name: "Victor",
+  avatarUrl: "https://example.com/avatar.jpg",
+  profileUrl: "https://github.com/ub-victor",
+  bio: "Maintainer",
+  company: null,
+};
+
+beforeEach(() => vi.resetAllMocks());
+
+describe("GET /api/contributors", () => {
+  it("returns 200 and contributors list", async () => {
+    vi.mocked(contributorsService.readContributors).mockResolvedValue([
+      mockContributor,
+    ]);
+
+    const res = await request(app).get("/api/contributors");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(vi.mocked(contributorsService.readContributors)).toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/contributors/refresh", () => {
+  it("returns 200 and triggers refresh when admin key provided", async () => {
+    vi.mocked(contributorsService.refreshContributors).mockResolvedValue({
+      totalParsed: 1,
+      success: 1,
+      failures: 0,
+      failedList: [],
+    });
+
+    const res = await request(app)
+      .post("/api/contributors/refresh")
+      .set("x-api-key", "test-admin-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(
+      vi.mocked(contributorsService.refreshContributors),
+    ).toHaveBeenCalled();
+  });
+
+  it("returns 403 when admin key is missing or invalid", async () => {
+    const res = await request(app).post("/api/contributors/refresh");
+
+    expect(res.status).toBe(403);
+    expect(
+      vi.mocked(contributorsService.refreshContributors),
+    ).not.toHaveBeenCalled();
+  });
+});

--- a/src/controllers/contributors.controller.ts
+++ b/src/controllers/contributors.controller.ts
@@ -14,10 +14,9 @@ export async function getContributors(
   try {
     let contributors = await readContributors();
 
-    // If readContributors returns an empty list (or nothing), fall back to the
-    // legacy contributor service and normalize legacy profiles into the
-    // modern `Contributor` shape so TypeScript and the rest of the codebase
-    // can consume a consistent type.
+    // If readContributors returns an empty list, fall back to the legacy
+    // contributor service and normalize legacy profiles into the modern
+    // Contributor shape.
     if (!Array.isArray(contributors) || contributors.length === 0) {
       const legacy = await contributorService.getContributors();
       contributors = legacy.map((p: unknown) => {

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -93,6 +93,16 @@ async function updateEvent(
 ) {
   let newPublicId: string | undefined;
   try {
+    if (req.body.date && isNaN(new Date(req.body.date as string).getTime())) {
+      return response.failure(res, "Invalid date format for 'date'", 400);
+    }
+    if (
+      req.body.endDate &&
+      isNaN(new Date(req.body.endDate as string).getTime())
+    ) {
+      return response.failure(res, "Invalid date format for 'endDate'", 400);
+    }
+
     const existing = await eventService.findEventById(req.params.id);
     if (!existing) return response.failure(res, "Event not found", 404);
 

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -1,7 +1,6 @@
 import { Request, Response, NextFunction } from "express";
 import memberService from "../services/member.service";
 import response from "../utils/response";
-import { CodingLevel } from "../generated/prisma/client";
 import { parseRequestBody } from "../utils/validation";
 import {
   createMemberSchema,
@@ -9,8 +8,6 @@ import {
   CreateMemberInput,
   UpdateMemberInput,
 } from "../schemas/member.schema";
-
-const allowedCodingLevels = new Set(Object.values(CodingLevel));
 
 async function findAllMembers(
   _req: Request,
@@ -73,17 +70,6 @@ async function updateMember(
     const filtered = Object.fromEntries(
       Object.entries(data).filter(([, v]) => v !== "" && v !== undefined),
     ) as UpdateMemberInput;
-
-    if (
-      filtered.codingLevel !== undefined &&
-      !allowedCodingLevels.has(filtered.codingLevel)
-    ) {
-      return response.failure(
-        res,
-        "Invalid codingLevel. Allowed values: beginner, intermediate, advanced",
-        400,
-      );
-    }
 
     const updatedMember = await memberService.updateMember(
       req.params.id,

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -9,7 +9,9 @@ type ReviewBody = Omit<Review, "id" | "createdAt" | "updatedAt">;
 
 type CreateReviewBody = Omit<ReviewBody, "profileUrl" | "profilePublicId">;
 
-type UpdateReviewBody = Partial<Omit<ReviewBody, "profileUrl" | "profilePublicId">>;
+type UpdateReviewBody = Partial<
+  Omit<ReviewBody, "profileUrl" | "profilePublicId">
+>;
 
 async function findAll(_req: Request, res: Response, next: NextFunction) {
   try {

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -1,15 +1,25 @@
 import { Request, Response, NextFunction } from "express";
+import { Prisma, Review } from "../generated/prisma/client";
 import reviewService from "../services/review.service";
 import response from "../utils/response";
-import { Review } from "../generated/prisma/client";
 import { destroyImage, uploadBuffer } from "../utils/cloudinary-upload";
+import trimStrings from "../utils/trim-strings";
 
 type ReviewBody = Omit<Review, "id" | "createdAt" | "updatedAt">;
+
+type CreateReviewBody = Omit<ReviewBody, "profileUrl" | "profilePublicId">;
+
+type UpdateReviewBody = Partial<Omit<ReviewBody, "profileUrl" | "profilePublicId">>;
 
 async function findAll(_req: Request, res: Response, next: NextFunction) {
   try {
     const reviews = await reviewService.findAll();
-    response.success(res, reviews, 200, "Reviews retrieved successfully");
+    return response.success(
+      res,
+      reviews,
+      200,
+      "Reviews retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }
@@ -32,11 +42,7 @@ async function findById(
 }
 
 async function create(
-  req: Request<
-    unknown,
-    unknown,
-    Omit<ReviewBody, "profileUrl" | "profilePublicId">
-  >,
+  req: Request<unknown, unknown, CreateReviewBody>,
   res: Response,
   next: NextFunction,
 ) {
@@ -52,13 +58,14 @@ async function create(
     );
     publicId = uploaded.public_id;
 
+    const data = trimStrings(req.body as CreateReviewBody);
     const newReview = await reviewService.create({
-      ...req.body,
+      ...data,
       profileUrl: uploaded.secure_url,
       profilePublicId: uploaded.public_id,
     });
 
-    response.success(res, newReview, 201, "Review created successfully");
+    return response.success(res, newReview, 201, "Review created successfully");
   } catch (err) {
     if (publicId) await destroyImage(publicId);
     next(err);
@@ -66,11 +73,7 @@ async function create(
 }
 
 async function update(
-  req: Request<
-    { id: string },
-    unknown,
-    Partial<Omit<ReviewBody, "profileUrl" | "profilePublicId">>
-  >,
+  req: Request<{ id: string }, unknown, UpdateReviewBody>,
   res: Response,
   next: NextFunction,
 ) {
@@ -79,9 +82,12 @@ async function update(
     const existing = await reviewService.findById(req.params.id);
     if (!existing) return response.failure(res, "Review not found", 404);
 
-    const data: Partial<ReviewBody> = Object.fromEntries(
-      Object.entries(req.body).filter(([, v]) => v !== ""),
-    ) as Partial<ReviewBody>;
+    const trimmedBody = trimStrings(req.body as UpdateReviewBody);
+    const data = Object.fromEntries(
+      Object.entries(trimmedBody).filter(
+        ([, value]) => value !== "" && value !== undefined,
+      ),
+    ) as Prisma.ReviewUpdateInput;
 
     if (req.file) {
       const uploaded = await uploadBuffer(
@@ -99,7 +105,12 @@ async function update(
       await destroyImage(existing.profilePublicId);
     }
 
-    response.success(res, updatedReview, 200, "Review updated successfully");
+    return response.success(
+      res,
+      updatedReview,
+      200,
+      "Review updated successfully",
+    );
   } catch (err) {
     if (newPublicId) await destroyImage(newPublicId);
     next(err);
@@ -118,7 +129,7 @@ async function deleteReview(
     await reviewService.delete(req.params.id);
     if (existing.profilePublicId) await destroyImage(existing.profilePublicId);
 
-    response.success(res, null, 204, "Review deleted successfully");
+    return response.success(res, null, 204, "Review deleted successfully");
   } catch (err) {
     next(err);
   }

--- a/src/schemas/member.schema.ts
+++ b/src/schemas/member.schema.ts
@@ -1,5 +1,11 @@
 import { z } from "zod";
 
+const codingLevelEnum = z.enum([
+  "beginner",
+  "intermediate",
+  "advanced",
+] as const);
+
 export const createMemberSchema = z.object({
   name: z.string().min(1, "Name is required").trim(),
   email: z
@@ -10,13 +16,11 @@ export const createMemberSchema = z.object({
   githubUsername: z.string().min(1, "GitHub username is required").trim(),
   orgName: z.string().min(1, "Organization name is required").trim(),
   joinReason: z.string().min(1, "Join reason is required").trim(),
-  codingLevel: z.enum(["beginner", "intermediate", "advanced"] as const),
+  codingLevel: codingLevelEnum,
 });
 
 export const updateMemberSchema = createMemberSchema.partial().extend({
-  codingLevel: z
-    .enum(["beginner", "intermediate", "advanced"] as const)
-    .optional(),
+  codingLevel: codingLevelEnum.optional(),
 });
 
 export type CreateMemberInput = z.infer<typeof createMemberSchema>;

--- a/src/services/contributors.service.ts
+++ b/src/services/contributors.service.ts
@@ -5,16 +5,23 @@ import { gh } from "./github.service";
 const CONTRIBUTORS_JSON_PATH = path.join(process.cwd(), "contributors.json");
 const CONTRIBUTORS_MD_PATH = path.join(process.cwd(), "CONTRIBUTORS.md");
 
-export interface Contributor {
+export interface ContributorProfile {
   login: string;
-  name: string;
+  name: string | null;
   avatarUrl: string;
   profileUrl: string;
-  bio: string;
-  company: string;
+  bio: string | null;
+  company: string | null;
 }
 
-export async function readContributors(): Promise<Contributor[]> {
+export type ContributorRefreshResult = {
+  totalParsed: number;
+  success: number;
+  failures: number;
+  failedList: Array<{ login: string; error: string }>;
+};
+
+export async function readContributors(): Promise<ContributorProfile[]> {
   try {
     const data = await fs.readFile(CONTRIBUTORS_JSON_PATH, "utf-8");
     return JSON.parse(data);
@@ -24,8 +31,7 @@ export async function readContributors(): Promise<Contributor[]> {
   }
 }
 
-export async function refreshContributors() {
-  const mdRaw = await fs.readFile(CONTRIBUTORS_MD_PATH, "utf-8");
+export async function refreshContributors(): Promise<ContributorRefreshResult> {
 
   const usernames = mdRaw
     .split("\n")
@@ -49,11 +55,11 @@ export async function refreshContributors() {
         profileUrl: data.html_url,
         bio: data.bio || "",
         company: data.company || "",
-      } as Contributor;
+      } as ContributorProfile;
     }),
   );
 
-  const contributors: Contributor[] = [];
+  const contributors: ContributorProfile[] = [];
   const successful: string[] = [];
   const failed: Array<{ login: string; error: string }> = [];
 

--- a/src/services/contributors.service.ts
+++ b/src/services/contributors.service.ts
@@ -32,10 +32,11 @@ export async function readContributors(): Promise<ContributorProfile[]> {
 }
 
 export async function refreshContributors(): Promise<ContributorRefreshResult> {
+  const mdRaw = await fs.readFile(CONTRIBUTORS_MD_PATH, "utf-8");
 
   const usernames = mdRaw
     .split("\n")
-    .map((line) => line.trim())
+    .map((line) => line.trim().replace(/^[-*+]?\s*/, ""))
     .filter(
       (line) =>
         line &&
@@ -47,14 +48,14 @@ export async function refreshContributors(): Promise<ContributorRefreshResult> {
   const results = await Promise.allSettled(
     usernames.map(async (username) => {
       const res = await gh(`/users/${username}`);
-      const data = await res.json();
+      const data = (await res.json()) as Record<string, unknown>;
       return {
-        login: data.login,
-        name: data.name || data.login,
-        avatarUrl: data.avatar_url,
-        profileUrl: data.html_url,
-        bio: data.bio || "",
-        company: data.company || "",
+        login: String(data.login),
+        name: data.name ? String(data.name) : String(data.login),
+        avatarUrl: String(data.avatar_url),
+        profileUrl: String(data.html_url),
+        bio: data.bio ? String(data.bio) : "",
+        company: data.company ? String(data.company) : "",
       } as ContributorProfile;
     }),
   );
@@ -70,7 +71,11 @@ export async function refreshContributors(): Promise<ContributorRefreshResult> {
       contributors.push(result.value);
       successful.push(username);
     } else {
-      failed.push({ login: username, error: result.reason.message });
+      const error =
+        result.reason instanceof Error
+          ? result.reason.message
+          : String(result.reason);
+      failed.push({ login: username, error });
     }
   }
 

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -14,9 +14,7 @@ export async function findById(id: string): Promise<Review | null> {
 }
 
 export async function create(data: Prisma.ReviewCreateInput): Promise<Review> {
-  return prisma.review.create({
-    data,
-  });
+  return prisma.review.create({ data });
 }
 
 export async function update(

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     environment: "node",
     include: ["src/**/*.test.ts"],
     setupFiles: ["./vitest.setup.ts"],
+    include: ["src/**/*.test.ts"],
+    exclude: ["dist/**", "node_modules/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
This PR adds contributors endpoints to read cached profile data from contributors.json and refresh the cache from CONTRIBUTORS.md. It includes admin-protected refresh behavior, OpenAPI docs, and GitHub profile fetching via env.GITHUB_TOKEN.

## Related issue

Closes #50

## How did you test it?

- Ran `npm test` locally (all tests pass)
- Built the project with `npm run build`
- Added unit tests for contributors endpoints (see `src/controllers/contributors.controller.test.ts`)

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [x] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
