### PR TITLE
Add Zod validation for request bodies

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -372,108 +372,7 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
 
-  /reviews:
-    get:
-      tags: [Reviews]
-      summary: List all reviews
-      responses:
-        "200":
-          description: Reviews retrieved successfully
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/ApiSuccess"
-                  - type: object
-                    properties:
-                      data:
-                        type: array
-                        items: { $ref: "#/components/schemas/Review" }
-        "500": { $ref: "#/components/responses/InternalError" }
-    post:
-      tags: [Reviews]
-      summary: Create a review
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema: { $ref: "#/components/schemas/ReviewInput" }
-      responses:
-        "201":
-          description: Review created successfully
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/ApiSuccess"
-                  - type: object
-                    properties:
-                      data: { $ref: "#/components/schemas/Review" }
-        "400": { $ref: "#/components/responses/BadRequest" }
-        "500": { $ref: "#/components/responses/InternalError" }
-
-  /reviews/{id}:
-    parameters:
-      - in: path
-        name: id
-        required: true
-        schema: { type: string, format: uuid }
-    get:
-      tags: [Reviews]
-      summary: Get a review by id
-      responses:
-        "200":
-          description: Review retrieved successfully
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/ApiSuccess"
-                  - type: object
-                    properties:
-                      data: { $ref: "#/components/schemas/Review" }
-        "404": { $ref: "#/components/responses/NotFound" }
-        "500": { $ref: "#/components/responses/InternalError" }
-    put:
-      tags: [Reviews]
-      summary: Update a review (admin only)
-      security:
-        - adminApiKey: []
-      requestBody:
-        required: true
-        content:
-          multipart/form-data:
-            schema: { $ref: "#/components/schemas/ReviewUpdateInput" }
-      responses:
-        "200":
-          description: Review updated successfully
-          content:
-            application/json:
-              schema:
-                allOf:
-                  - $ref: "#/components/schemas/ApiSuccess"
-                  - type: object
-                    properties:
-                      data: { $ref: "#/components/schemas/Review" }
-        "401": { $ref: "#/components/responses/Unauthorized" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
-        "500": { $ref: "#/components/responses/InternalError" }
-    delete:
-      tags: [Reviews]
-      summary: Delete a review (admin only)
-      security:
-        - adminApiKey: []
-      responses:
-        "204":
-          description: Review deleted successfully
-          content:
-            application/json:
-              schema: { $ref: "#/components/schemas/ApiSuccess" }
-        "401": { $ref: "#/components/responses/Unauthorized" }
-        "403": { $ref: "#/components/responses/Forbidden" }
-        "404": { $ref: "#/components/responses/NotFound" }
-        "500": { $ref: "#/components/responses/InternalError" }
+  
 
   /projects:
     get:
@@ -986,39 +885,7 @@ components:
         email: { type: string, format: email }
         partnershipReason: { type: string }
 
-    Review:
-      type: object
-      properties:
-        id: { type: string, format: uuid }
-        name: { type: string }
-        profileUrl: { type: string }
-        profilePublicId: { type: string }
-        role: { type: string }
-        message: { type: string }
-        createdAt: { type: string, format: date-time }
-        updatedAt: { type: string, format: date-time }
-
-    ReviewInput:
-      type: object
-      required: [name, role, file, message]
-      properties:
-        name: { type: string }
-        role: { type: string }
-        file: { type: string, format: binary, description: "Profile image" }
-        message: { type: string }
-
-    ReviewUpdateInput:
-      type: object
-      properties:
-        name: { type: string }
-        role: { type: string }
-        file:
-          {
-            type: string,
-            format: binary,
-            description: "Replacement profile image (optional)",
-          }
-        message: { type: string }
+    
 
     Project:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -372,8 +372,6 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
 
-  
-
   /projects:
     get:
       tags: [Projects]
@@ -884,8 +882,6 @@ components:
         description: { type: string }
         email: { type: string, format: email }
         partnershipReason: { type: string }
-
-    
 
     Project:
       type: object

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -372,6 +372,109 @@ paths:
         "404": { $ref: "#/components/responses/NotFound" }
         "500": { $ref: "#/components/responses/InternalError" }
 
+  /reviews:
+    get:
+      tags: [Reviews]
+      summary: List all reviews
+      responses:
+        "200":
+          description: Reviews retrieved successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items: { $ref: "#/components/schemas/Review" }
+        "500": { $ref: "#/components/responses/InternalError" }
+    post:
+      tags: [Reviews]
+      summary: Create a review
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema: { $ref: "#/components/schemas/ReviewInput" }
+      responses:
+        "201":
+          description: Review created successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/Review" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /reviews/{id}:
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema: { type: string, format: uuid }
+    get:
+      tags: [Reviews]
+      summary: Get a review by id
+      responses:
+        "200":
+          description: Review retrieved successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/Review" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+    put:
+      tags: [Reviews]
+      summary: Update a review (admin only)
+      security:
+        - adminApiKey: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema: { $ref: "#/components/schemas/ReviewUpdateInput" }
+      responses:
+        "200":
+          description: Review updated successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    properties:
+                      data: { $ref: "#/components/schemas/Review" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+    delete:
+      tags: [Reviews]
+      summary: Delete a review (admin only)
+      security:
+        - adminApiKey: []
+      responses:
+        "204":
+          description: Review deleted successfully
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiSuccess" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
   /projects:
     get:
       tags: [Projects]
@@ -882,6 +985,40 @@ components:
         description: { type: string }
         email: { type: string, format: email }
         partnershipReason: { type: string }
+
+    Review:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        name: { type: string }
+        profileUrl: { type: string }
+        profilePublicId: { type: string }
+        role: { type: string }
+        message: { type: string }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+
+    ReviewInput:
+      type: object
+      required: [name, role, file, message]
+      properties:
+        name: { type: string }
+        role: { type: string }
+        file: { type: string, format: binary, description: "Profile image" }
+        message: { type: string }
+
+    ReviewUpdateInput:
+      type: object
+      properties:
+        name: { type: string }
+        role: { type: string }
+        file:
+          {
+            type: string,
+            format: binary,
+            description: "Replacement profile image (optional)",
+          }
+        message: { type: string }
 
     Project:
       type: object

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -7,22 +7,26 @@ import trimStrings from "../utils/trim-strings";
 
 type ReviewBody = Omit<Review, "id" | "createdAt" | "updatedAt">;
 
-async function findAll(_req: Request, res: Response, next: NextFunction) {
+async function findAllReviews(
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   try {
-    const reviews = await reviewService.findAll();
+    const reviews = await reviewService.findAllReviews();
     response.success(res, reviews, 200, "Reviews retrieved successfully");
   } catch (err) {
     next(err);
   }
 }
 
-async function findById(
+async function findReviewById(
   req: Request<{ id: string }>,
   res: Response,
   next: NextFunction,
 ) {
   try {
-    const review = await reviewService.findById(req.params.id);
+    const review = await reviewService.findReviewById(req.params.id);
     if (!review) {
       return response.failure(res, "Review not found", 404);
     }
@@ -32,7 +36,7 @@ async function findById(
   }
 }
 
-async function create(
+async function addReview(
   req: Request<
     unknown,
     unknown,
@@ -42,7 +46,7 @@ async function create(
   next: NextFunction,
 ) {
   if (!req.file) {
-    return response.failure(res, "Profile image is required", 400);
+    return response.failure(res, "Profile image file is required", 400);
   }
 
   let publicId: string | undefined;
@@ -53,7 +57,7 @@ async function create(
     );
     publicId = uploaded.public_id;
 
-    const newReview = await reviewService.create({
+    const newReview = await reviewService.addReview({
       ...trimStrings(req.body),
       profileUrl: uploaded.secure_url,
       profilePublicId: uploaded.public_id,
@@ -66,18 +70,18 @@ async function create(
   }
 }
 
-async function update(
+async function updateReview(
   req: Request<
     { id: string },
     unknown,
-    Partial<Omit<ReviewBody, "profileUrl" | "profilePublicId">>
+    Partial<Omit<ReviewBody, "profilePublicId">>
   >,
   res: Response,
   next: NextFunction,
 ) {
   let newPublicId: string | undefined;
   try {
-    const existing = await reviewService.findById(req.params.id);
+    const existing = await reviewService.findReviewById(req.params.id);
     if (!existing) return response.failure(res, "Review not found", 404);
 
     const data: Partial<ReviewBody> = Object.fromEntries(
@@ -94,7 +98,7 @@ async function update(
       data.profilePublicId = uploaded.public_id;
     }
 
-    const updatedReview = await reviewService.update(req.params.id, data);
+    const updatedReview = await reviewService.updateReview(req.params.id, data);
 
     if (req.file && existing.profilePublicId) {
       await destroyImage(existing.profilePublicId);
@@ -113,12 +117,11 @@ async function deleteReview(
   next: NextFunction,
 ) {
   try {
-    const existing = await reviewService.findById(req.params.id);
+    const existing = await reviewService.findReviewById(req.params.id);
     if (!existing) return response.failure(res, "Review not found", 404);
 
-    await reviewService.delete(req.params.id);
+    await reviewService.deleteReview(req.params.id);
     if (existing.profilePublicId) await destroyImage(existing.profilePublicId);
-
     response.success(res, null, 204, "Review deleted successfully");
   } catch (err) {
     next(err);
@@ -126,9 +129,9 @@ async function deleteReview(
 }
 
 export default {
-  findAll,
-  findById,
-  create,
-  update,
-  delete: deleteReview,
+  findAllReviews,
+  findReviewById,
+  addReview,
+  updateReview,
+  deleteReview,
 };

--- a/src/routes/review.routes.ts
+++ b/src/routes/review.routes.ts
@@ -1,20 +1,16 @@
 import { Router } from "express";
 import reviewController from "../controllers/review.controller";
-import auth from "../middlewares/auth.middleware";
+import authMiddleware from "../middlewares/auth.middleware";
 import { upload } from "../middlewares/upload.middleware";
 
-const router = Router();
+const route = Router();
 
-router.get("/", reviewController.findAll);
-router.get("/:id", reviewController.findById);
+route.get("/", reviewController.findAllReviews);
+route.get("/:id", reviewController.findReviewById);
+route.post("/", upload.single("file"), reviewController.addReview);
 
-router.post("/", upload.single("file"), reviewController.create);
-router.put(
-  "/:id",
-  auth.requireAdmin,
-  upload.single("file"),
-  reviewController.update,
-);
-router.delete("/:id", auth.requireAdmin, reviewController.delete);
+route.use(authMiddleware.requireAdmin);
+route.put("/:id", upload.single("file"), reviewController.updateReview);
+route.delete("/:id", reviewController.deleteReview);
 
-export default router;
+export default route;

--- a/src/schemas/event.schema.ts
+++ b/src/schemas/event.schema.ts
@@ -53,27 +53,25 @@ const eventBaseSchema = z.object({
     .optional()
     .nullable()
     .transform((v) => {
-      if (!v) return [];
+      if (v === undefined) return undefined;
+      if (v === null) return [];
       if (Array.isArray(v)) return v.map(String);
-      if (typeof v === "string") {
-        const trimmed = v.trim();
-        if (!trimmed) return [];
-        if (trimmed.startsWith("[")) {
-          try {
-            const parsed = JSON.parse(trimmed);
-            if (Array.isArray(parsed)) return parsed.map(String);
-          } catch {
-            // fall through
-          }
+
+      const trimmed = v.trim();
+      if (!trimmed) return [];
+      if (trimmed.startsWith("[")) {
+        try {
+          const parsed = JSON.parse(trimmed);
+          if (Array.isArray(parsed)) return parsed.map(String);
+        } catch {
+          // fall through
         }
-        return trimmed
-          .split(",")
-          .map((s) => s.trim())
-          .filter(Boolean);
       }
-      return [];
-    })
-    .default([]),
+      return trimmed
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }),
   registerUrl: z.string().trim().optional().nullable(),
 });
 

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -1,44 +1,37 @@
-import { Prisma, Review } from "../generated/prisma/client";
 import { prisma } from "../config/prisma";
+import { Review } from "../generated/prisma/client";
 
-export async function findAll(): Promise<Review[]> {
-  return prisma.review.findMany({
-    orderBy: { createdAt: "desc" },
-  });
+async function findAllReviews(): Promise<Review[]> {
+  return prisma.review.findMany({ orderBy: { createdAt: "desc" } });
 }
 
-export async function findById(id: string): Promise<Review | null> {
-  return prisma.review.findUnique({
-    where: { id },
-  });
+async function findReviewById(id: string): Promise<Review | null> {
+  return prisma.review.findUnique({ where: { id } });
 }
 
-export async function create(data: Prisma.ReviewCreateInput): Promise<Review> {
-  return prisma.review.create({
-    data,
-  });
-}
-
-export async function update(
-  id: string,
-  data: Prisma.ReviewUpdateInput,
+async function addReview(
+  reviewData: Omit<Review, "id" | "createdAt" | "updatedAt">,
 ): Promise<Review> {
-  return prisma.review.update({
-    where: { id },
-    data,
-  });
+  return prisma.review.create({ data: reviewData });
 }
 
-export async function deleteReview(id: string): Promise<Review> {
-  return prisma.review.delete({
-    where: { id },
-  });
+async function updateReview(
+  id: string,
+  reviewData: Partial<
+    Omit<Review, "id" | "createdAt" | "updatedAt" | "profilePublicId">
+  >,
+): Promise<Review> {
+  return prisma.review.update({ where: { id }, data: reviewData });
+}
+
+async function deleteReview(id: string): Promise<Review> {
+  return prisma.review.delete({ where: { id } });
 }
 
 export default {
-  findAll,
-  findById,
-  create,
-  update,
-  delete: deleteReview,
+  findAllReviews,
+  findReviewById,
+  addReview,
+  updateReview,
+  deleteReview,
 };


### PR DESCRIPTION
From #35
Adds Zod validation for request bodies across Members, Partners, Events, and Projects.

What I changed:
- Added dependency: zod
- New schemas in src/schemas: member.schema.ts, partner.schema.ts, event.schema.ts, project.schema.ts
- Updated controllers to validate input and return 400 on invalid input:
  - src/controllers/member.controller.ts
  - src/controllers/partner.controllers.ts
  - src/controllers/event.controller.ts
  - src/controllers/project.controller.ts

Notes:
- Validates email, URLs, date strings, enums, slug format, non-negative numbers, and ensure registered does not exceed capacity.
- TypeScript build passes locally (ran 
> oskbackend@1.0.0 build
> tsc).

Please review and let me know if you want the PR split into smaller PRs (one per resource).

Done by @ub-victor 