### PR TITLE
Fix/health db check

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -39,6 +39,7 @@ paths:
                         properties:
                           status: { type: string, example: ok }
                           uptime: { type: number }
+                          db: { type: string, example: ok }
         "503":
           description: Database unreachable
           content:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -40,20 +40,20 @@ paths:
                           status: { type: string, example: ok }
                           uptime: { type: number }
         "503":
-        description: Database unreachable
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                status:
-                  type: string
-                  example: ok
-                uptime:
-                  type: number
-                db:
-                  type: string
-                  example: unreachable
+          description: Database unreachable
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+                  uptime:
+                    type: number
+                  db:
+                    type: string
+                    example: unreachable
   /members:
     get:
       tags: [Members]

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -39,7 +39,21 @@ paths:
                         properties:
                           status: { type: string, example: ok }
                           uptime: { type: number }
-
+        "503":
+        description: Database unreachable
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                status:
+                  type: string
+                  example: ok
+                uptime:
+                  type: number
+                db:
+                  type: string
+                  example: unreachable
   /members:
     get:
       tags: [Members]

--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -1,8 +1,24 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
+import { prisma } from "../config/prisma";
 import response from "../utils/response";
 
-function checkHealth(_req: Request, res: Response) {
-  response.success(res, { status: "ok", uptime: process.uptime() });
+async function checkHealth(_req: Request, res: Response, _next: NextFunction) {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+
+    response.success(
+      res,
+      { status: "ok", uptime: process.uptime(), db: "ok" },
+      200,
+      "Service is healthy",
+    );
+  } catch {
+    res.status(503).json({
+      status: "ok",
+      uptime: process.uptime(),
+      db: "unreachable",
+    });
+  }
 }
 
 export default { checkHealth };


### PR DESCRIPTION
## What does this PR do?
Adds a lightweight database connectivity check to `GET /api/health`. Previously the endpoint only returned process uptime, meaning it could return `200` even when the app couldn't talk to Postgres. It now runs `SELECT 1` against the database and reflects the real connectivity status in the response.

## Related issue
Closes #10

## How did you test it?
- Started Docker and hit `GET /api/health` — confirmed `{ db: "ok" }` with `200`
- Stopped Docker with `docker compose stop` and hit the endpoint — confirmed `{ db: "unreachable" }` with `503`
- Restarted Docker — confirmed recovery back to `200` with `{ db: "ok" }`

## Checklist
- [x] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed

## Changes
- Returns `{ db: "ok" }` with `200` when Postgres is reachable
- Returns `{ db: "unreachable" }` with `503` when Postgres is down
- Updated `docs/openapi.yaml` to document the new response shapes and `503` status
- Applied prettier formatting across the codebase (pre-existing warnings)