### PR TITLE
fix: Validate required fields in addEvent controller (#32)

### DIFF
--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -97,6 +97,13 @@ async function addEvent(
     return response.failure(res, "Image file is required", 400);
   }
 
+  const requiredFields = ["title", "description", "category", "location", "date"];
+  for (const field of requiredFields) {
+    if (!req.body[field]) {
+      return response.failure(res, `Missing required field: ${field}`, 400);
+    }
+  }
+
   let publicId: string | undefined;
   try {
     const uploaded = await uploadBuffer(req.file.buffer, FOLDER);


### PR DESCRIPTION
### Description
This pull request resolves **Issue #32**. 

Previously, the `addEvent` controller did not validate if required body fields were provided before trying to create an `Event`. Missing required fields would cause an unhandled Database error instead of a proper `400 Bad Request`.

### Changes Made
- Added a validation block inside `src/controllers/event.controller.ts` for the `addEvent` endpoint.
- The controller now explicitly checks for the presence of `"title", "description", "category", "location", "date"`.
- If any of these fields are missing, the endpoint gracefully returns a `400` status with a descriptive message (`"Missing required field: <field>"`).

### Testing
- Tested the endpoint to confirm it intercepts missing fields before reaching the Prisma client.
