### PR TITLE
fix: Add format validation for Project slug (#22)

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -61,6 +61,10 @@ async function addProject(
 ) {
   if (!req.file) return response.failure(res, "Image file is required", 400);
 
+  if (req.body.slug && !/^[a-zA-Z0-9-_]+$/.test(req.body.slug)) {
+    return response.failure(res, "Invalid slug format. Only alphanumeric characters, dashes, and underscores are allowed.", 400);
+  }
+
   let publicId: string | undefined;
   try {
     const uploaded = await uploadBuffer(req.file.buffer, FOLDER);
@@ -108,7 +112,12 @@ async function updateProject(
 
     const data: Record<string, unknown> = {};
     const b = req.body;
-    if (b.slug) data.slug = b.slug;
+    if (b.slug) {
+      if (!/^[a-zA-Z0-9-_]+$/.test(b.slug)) {
+        return response.failure(res, "Invalid slug format. Only alphanumeric characters, dashes, and underscores are allowed.", 400);
+      }
+      data.slug = b.slug;
+    }
     if (b.repoOwner) data.repoOwner = b.repoOwner;
     if (b.repoName) data.repoName = b.repoName;
     if (b.tagline) data.tagline = b.tagline;


### PR DESCRIPTION
### Description
This pull request resolves **Issue #22**. 

Previously, the `slug` field for Projects had no format validation when a project was created or updated. This allowed users to input strings containing spaces and special characters, which could break URL routing and cause database consistency issues.

### Changes Made
- Added a Regular Expression check (`/^[a-zA-Z0-9-_]+$/`) to the `addProject` and `updateProject` controllers in `src/controllers/project.controller.ts`.
- The endpoints now verify that the `slug` contains only alphanumeric characters, dashes (`-`), and underscores (`_`).
- If an invalid slug is provided, the API intercepts it and returns a `400 Bad Request` with the message: `"Invalid slug format. Only alphanumeric characters, dashes, and underscores are allowed."`

### Testing
- Verified locally that spaces and special characters in the slug field are correctly rejected before hitting the Prisma client.
