### PR TITLE
Fix/http 204 no body

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To stop the database: `docker compose down` (add `-v` to wipe the data).
 Interractive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
+If `ADMIN_API_KEY` is missing at startup, the server logs a warning and admin endpoints will continue to return `500` until the key is configured.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Interractive Swagger UI is available at `http://localhost:3000/api/docs` once th
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 If `ADMIN_API_KEY` is missing at startup, the server logs a warning and admin endpoints will continue to return `500` until the key is configured.
+Delete endpoints return `204 No Content` with an empty response body to stay compliant with the HTTP spec.
 
 ## Contributors
 

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -5,6 +5,7 @@ import response from "../utils/response";
 function requireAdmin(req: Request, res: Response, next: NextFunction) {
   const apiKey = req.headers["x-api-key"];
 
+  // Keep the request-time guard so misconfigured environments fail safely.
   if (!env.adminApiKey) {
     return response.failure(res, "Server admin key not configured", 500);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,13 @@
 import app from "./app";
 import { env } from "./config/env";
 
+// Surface misconfiguration during startup instead of only at request time.
+if (!env.adminApiKey) {
+  console.warn(
+    "WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.",
+  );
+}
+
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Response } from "express";
+import response from "./response";
+
+describe("response.success", () => {
+  it("ends the response without a body for 204 No Content", () => {
+    const end = vi.fn();
+    const json = vi.fn();
+    const status = vi.fn().mockReturnValue({ end, json });
+    const res = { status } as unknown as Response;
+
+    response.success(res, null, 204, "Deleted successfully");
+
+    expect(status).toHaveBeenCalledWith(204);
+    expect(end).toHaveBeenCalledOnce();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("sends the standard JSON payload for non-204 responses", () => {
+    const json = vi.fn();
+    const status = vi.fn().mockReturnValue({ json });
+    const res = { status } as unknown as Response;
+
+    response.success(res, { id: "1" }, 200, "OK");
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: "OK",
+      data: { id: "1" },
+    });
+  });
+});

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -6,6 +6,11 @@ function success<T>(
   status: number = 200,
   message: string = "Success",
 ) {
+  if (status === 204) {
+    // HTTP 204 responses must not include a message body.
+    return res.status(status).end();
+  }
+
   return res.status(status).json({ success: true, message, data });
 }
 


### PR DESCRIPTION
## What does this PR do?

  Fixes 204 No Content responses so they no longer send a JSON body. The shared response helper now ends 204 responses correctly, and the change is documented with a focused test and a
  short README update.

  ## Related issue

  Closes #

  ## How did you test it?

  Ran npm test -- src/utils/response.test.ts to verify 204 responses use res.status(204).end() without a body, and ran npm run typecheck to confirm the change compiles cleanly. Existing
  supertest controller tests could not run in this sandbox because of a local listen EPERM restriction.

  ## Checklist

  - [ ] My code builds (npm run build)
  - [ ] I added or updated tests and npm test passes
  - [ ] I updated docs/openapi.yaml if I changed any routes
  - [ ] I added a Prisma migration if I changed schema.prisma
  - [x] I updated docs or .env.example if needed
