### PR TITLE
fix: Validate required fields in addMember controller (#33)

### DIFF
--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -38,6 +38,13 @@ async function addMember(
   next: NextFunction,
 ) {
   try {
+    const requiredFields = ["name", "email", "githubUsername", "orgName", "joinReason", "codingLevel"];
+    for (const field of requiredFields) {
+      if (!(req.body as Record<string, unknown>)[field]) {
+        return response.failure(res, `Missing required field: ${field}`, 400);
+      }
+    }
+
     const newMember = await memberService.addMember(req.body);
     response.success(res, newMember, 201, "Member created successfully");
   } catch (err) {


### PR DESCRIPTION
### Description
This pull request resolves **Issue #33**. 

Previously, the `addMember` controller did not validate if required body fields were provided before trying to create a `Member`. Missing required fields would bypass validation and crash the application with an unhandled Prisma Database error instead of a proper HTTP `400 Bad Request`.

### Changes Made
- Added a validation block inside `src/controllers/member.controller.ts` for the `addMember` endpoint.
- The controller now explicitly checks for the presence of `"name", "email", "githubUsername", "orgName", "joinReason", "codingLevel"`.
- If any of these fields are missing, the endpoint gracefully returns a `400` status with a descriptive message (`"Missing required field: <field>"`).

### Testing
- Tested the endpoint locally to confirm it intercepts missing fields and sends a `400` response before reaching the Prisma client.
