### PR TITLE
fix: Add date string validation to Event creation/update (#34)

### DIFF
--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -99,6 +99,13 @@ async function addEvent(
 
   let publicId: string | undefined;
   try {
+    if (req.body.date && isNaN(new Date(req.body.date as string).getTime())) {
+      return response.failure(res, "Invalid date format for 'date'", 400);
+    }
+    if (req.body.endDate && isNaN(new Date(req.body.endDate as string).getTime())) {
+      return response.failure(res, "Invalid date format for 'endDate'", 400);
+    }
+
     const uploaded = await uploadBuffer(req.file.buffer, FOLDER);
     publicId = uploaded.public_id;
 
@@ -123,6 +130,13 @@ async function updateEvent(
 ) {
   let newPublicId: string | undefined;
   try {
+    if (req.body.date && isNaN(new Date(req.body.date as string).getTime())) {
+      return response.failure(res, "Invalid date format for 'date'", 400);
+    }
+    if (req.body.endDate && isNaN(new Date(req.body.endDate as string).getTime())) {
+      return response.failure(res, "Invalid date format for 'endDate'", 400);
+    }
+
     const existing = await eventService.findEventById(req.params.id);
     if (!existing) return response.failure(res, "Event not found", 404);
 


### PR DESCRIPTION
### Description
This pull request Closes #34 . 

Previously, when a user provided an invalid date string in the `addEvent` or `updateEvent` endpoints, the controller would still try to parse it via `new Date()`. This resulted in an invalid `Date` object (with time `NaN`), which eventually crashed the application with an unhandled Prisma Database Error (`500 Internal Server Error`).

### Changes Made
- Added format validation for both `date` and `endDate` fields in `src/controllers/event.controller.ts`.
- The `addEvent` and `updateEvent` controllers now explicitly check if `isNaN(new Date(...).getTime())`.
- If an invalid date is detected, the API will safely intercept the request and return a `400 Bad Request` with the message `"Invalid date format for 'date'"` (or `'endDate'`).

### Testing
- Tested locally to confirm that passing invalid strings like `"hello"` or `"2025-99-99"` returns a graceful `400` response instead of crashing the backend.
