### PR TITLE
fix: Add default sort order to findAllMembers endpoint (#12)

### DIFF
--- a/src/services/member.service.ts
+++ b/src/services/member.service.ts
@@ -2,7 +2,7 @@ import { prisma } from "../config/prisma";
 import { Member } from "../generated/prisma/client";
 
 async function findAllMembers() {
-  return prisma.member.findMany();
+  return prisma.member.findMany({ orderBy: { name: "asc" } });
 }
 
 async function addMember(


### PR DESCRIPTION
### Description
This pull request resolves **Issue #12**. 

Similarly to #13, the `findAllMembers` service previously returned members in an unsorted array directly from the database query.

### Changes Made
- Modified `src/services/member.service.ts` to include an `orderBy` clause in the `prisma.member.findMany()` query.
- The endpoint now defaults to returning members sorted alphabetically by their `name` field in ascending order (`{ orderBy: { name: "asc" } }`).

### Testing
- Verified that GET requests to `/api/members` consistently return a nicely ordered alphabetical list of members instead of a random order.
