### PR TITLE
fix: Add default sort order to find  All Partners endpoint (#11)

### DIFF
--- a/src/services/partner.service.ts
+++ b/src/services/partner.service.ts
@@ -2,7 +2,7 @@ import { prisma } from "../config/prisma";
 import { Partner } from "../generated/prisma/client";
 
 async function findAllPartners() {
-  return prisma.partner.findMany();
+  return prisma.partner.findMany({ orderBy: { name: "asc" } });
 }
 
 async function addPartner(


### PR DESCRIPTION
### Description
This pull request Closes #11 . 

the `findAllPartners` service previously returned partners in an unsorted array directly from the database query.

### Changes Made
- Modified `src/services/partner.service.ts` to include an `orderBy` clause in the `prisma.partner.findMany()` query.
- The endpoint now defaults to returning partners sorted alphabetically by their `name` field in ascending order (`{ orderBy: { name: "asc" } }`).

### Testing
- Verified that GET requests to `/api/partners` consistently return a nicely ordered alphabetical list of partners instead of a random order.
