### PR TITLE
fix: Add existence check to updateMember controller (#6)

### DIFF
--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -51,6 +51,9 @@ async function updateMember(
   next: NextFunction,
 ) {
   try {
+    const existing = await memberService.findMemberById(req.params.id);
+    if (!existing) return response.failure(res, "Member not found", 404);
+
     const filtered = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<Omit<Member, "id">>;


### PR DESCRIPTION
### Description
This pull request resolves **Issue #6**. 

Previously, the `updateMember` controller passed the requested `id` directly to Prisma without first checking if a `Member` with that ID actually existed in the database. If a user provided a non-existent ID, the application crashed with an unhandled `P2025: Record to update not found` database error instead of returning a proper `404 Not Found`.

### Changes Made
- Modified `src/controllers/member.controller.ts` to include an existence check within the `updateMember` endpoint.
- The controller now attempts to `findMemberById(req.params.id)` before updating.
- If no member is found, the endpoint intercepts the request and cleanly returns a `404` status with the message `"Member not found"`.

### Testing
- Tested the endpoint locally to confirm that hitting `PUT /api/members/<invalid_id>` correctly returns a `404` error instead of a generic `500` error.
