### PR TITLE
fix: Secure POST /api/partners endpoint with admin auth guard (#7)

### DIFF
--- a/src/routes/partner.routes.ts
+++ b/src/routes/partner.routes.ts
@@ -7,9 +7,8 @@ const route = Router();
 
 route.get("/", partnerControllers.findAllPartners);
 route.get("/:id", partnerControllers.findPartnerById);
-route.post("/", upload.single("file"), partnerControllers.addPartner);
-
 route.use(authMiddleware.requireAdmin);
+route.post("/", upload.single("file"), partnerControllers.addPartner);
 route.put("/:id", upload.single("file"), partnerControllers.updatePartner);
 route.delete("/:id", partnerControllers.deletePartner);
 


### PR DESCRIPTION
### Description
This pull request resolves **Issue #7**. 

Previously, the `POST /api/partners` route was accidentally placed above the `route.use(authMiddleware.requireAdmin)` middleware declaration. Because of this, it was entirely public and could be accessed without admin authentication, allowing unauthorized users to create partners.

### Changes Made
- Modified `src/routes/partner.routes.ts` by moving the `route.post("/", ...)` endpoint below the `route.use(authMiddleware.requireAdmin)` definition.
- The `POST` route is now properly guarded by the admin authentication middleware, just like the `PUT` and `DELETE` routes.

### Testing
- Ensured that unauthenticated requests to `POST /api/partners` correctly return a `401 Unauthorized` (or `403 Forbidden`) response instead of proceeding to the controller logic.
