### PR TITLE
feat: Add database connectivity verification to health endpoint (#10)

### DIFF
--- a/src/controllers/health.controller.ts
+++ b/src/controllers/health.controller.ts
@@ -1,8 +1,14 @@
-import { Request, Response } from "express";
+import { Request, Response, NextFunction } from "express";
 import response from "../utils/response";
+import { prisma } from "../config/prisma";
 
-function checkHealth(_req: Request, res: Response) {
-  response.success(res, { status: "ok", uptime: process.uptime() });
+async function checkHealth(_req: Request, res: Response, next: NextFunction) {
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    response.success(res, { status: "ok", uptime: process.uptime(), db: "connected" });
+  } catch (err) {
+    res.status(503).json({ success: false, message: "Database connection failed", data: null });
+  }
 }
 
 export default { checkHealth };


### PR DESCRIPTION
### Description
This pull request resolves **Issue #10**. 

Previously, the `GET /api/health` endpoint merely returned `{ status: "ok" }` alongside the process uptime, without verifying whether the database connection was actually alive. If the database went down, load balancers checking the health endpoint would still assume the service was fully functional.

### Changes Made
- Modified `src/controllers/health.controller.ts` to convert the `checkHealth` function to be asynchronous.
- Added a lightweight query (`await prisma.$queryRaw'SELECT 1'`) to actively ping the database.
- If the database query is successful, the endpoint returns a `200 OK` status with `{ db: "connected" }`.
- If the database query fails or throws an error, the endpoint cleanly catches it and responds with a `503 Service Unavailable` status and the message `"Database connection failed"`.

### Testing
- Tested locally to verify that a successful database connection returns `200` while a forced DB disconnection accurately fails the health check with a `503`.
