### PR TITLE
fix: Add email format validation for Partners (#16)

### DIFF
--- a/src/controllers/partner.controllers.ts
+++ b/src/controllers/partner.controllers.ts
@@ -49,6 +49,10 @@ async function addPartner(
     return response.failure(res, "Logo file is required", 400);
   }
 
+  if (req.body.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(req.body.email)) {
+    return response.failure(res, "Invalid email format", 400);
+  }
+
   let publicId: string | undefined;
   try {
     const uploaded = await uploadBuffer(
@@ -87,6 +91,10 @@ async function updatePartner(
     const data: Partial<PartnerBody> = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<PartnerBody>;
+
+    if (data.email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(data.email)) {
+      return response.failure(res, "Invalid email format", 400);
+    }
 
     if (req.file) {
       const uploaded = await uploadBuffer(


### PR DESCRIPTION
### Description
This pull request resolves **Issue #16**. 

Previously, the `POST /api/partners` and `PUT /api/partners/:id` endpoints did not validate the format of the `email` field. A user could submit an invalid email like `"not_an_email"` or `"test@test"` and the application would save it directly to the database.

### Changes Made
- Modified `src/controllers/partner.controllers.ts` to include a Regular Expression check for the `email` field inside both the `addPartner` and `updatePartner` endpoints.
- If a provided email does not match standard email formatting rules (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`), the endpoint cleanly intercepts the request and returns a `400 Bad Request` with the message `"Invalid email format"`.

### Testing
- Tested the endpoint locally to ensure valid emails pass the check, while incorrectly formatted emails are correctly blocked with a `400` status.
