### PR TITLE
fix: Add URL format validation for partner websiteUrl (#14)

### DIFF
--- a/src/controllers/partner.controllers.ts
+++ b/src/controllers/partner.controllers.ts
@@ -49,6 +49,14 @@ async function addPartner(
     return response.failure(res, "Logo file is required", 400);
   }
 
+  if (req.body.websiteUrl) {
+    try {
+      new URL(req.body.websiteUrl as string);
+    } catch {
+      return response.failure(res, "Invalid websiteUrl format", 400);
+    }
+  }
+
   let publicId: string | undefined;
   try {
     const uploaded = await uploadBuffer(
@@ -87,6 +95,14 @@ async function updatePartner(
     const data: Partial<PartnerBody> = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<PartnerBody>;
+
+    if (data.websiteUrl) {
+      try {
+        new URL(data.websiteUrl as string);
+      } catch {
+        return response.failure(res, "Invalid websiteUrl format", 400);
+      }
+    }
 
     if (req.file) {
       const uploaded = await uploadBuffer(


### PR DESCRIPTION
### Description
This pull request resolves **Issue #14**. 

Previously, the `POST /api/partners` and `PUT /api/partners/:id` endpoints did not validate if the `websiteUrl` string was actually a valid, correctly formatted URL. A user could input any raw string (e.g., `"mywebsite"` instead of `"https://mywebsite.com"`) and the application would accept it, potentially breaking frontend links that expect standard URIs.

### Changes Made
- Modified `src/controllers/partner.controllers.ts` to include a validation check for the `websiteUrl` field inside both the `addPartner` and `updatePartner` endpoints.
- We utilize the native JavaScript `new URL()` constructor inside a `try/catch` block to test the formatting.
- If a provided `websiteUrl` fails to construct into a valid URL, the endpoint cleanly intercepts the request and returns a `400 Bad Request` with the message `"Invalid websiteUrl format"`.

### Testing
- Tested locally to ensure fully qualified URLs (e.g., `https://example.com`) pass the validation, while invalid strings (e.g., `www.example`) are correctly blocked with a `400` status.
