### PR TITLE
Fix/validate coding level

### DIFF
--- a/src/controllers/member.controller.test.ts
+++ b/src/controllers/member.controller.test.ts
@@ -75,7 +75,6 @@ describe("POST /api/members", () => {
 describe("PUT /api/members/:id", () => {
   it("returns 403 without admin key", async () => {
     const res = await request(app).put("/api/members/1").send({ name: "Bob" });
-
     expect(res.status).toBe(403);
   });
 
@@ -93,6 +92,15 @@ describe("PUT /api/members/:id", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.data.name).toBe("Bob");
+  });
+  it("returns 400 when codingLevel is invalid", async () => {
+    const res = await request(app)
+      .put("/api/members/1")
+      .set("x-api-key", ADMIN_KEY)
+      .send({ codingLevel: "expert" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
   });
 });
 

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -54,6 +54,19 @@ async function updateMember(
     const filtered = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<Omit<Member, "id">>;
+
+    const allowedCodingLevels = ["beginner", "intermediate", "advanced"];
+    if (
+      filtered.codingLevel &&
+      !allowedCodingLevels.includes(filtered.codingLevel)
+    ) {
+      return response.failure(
+        res,
+        "Invalid codingLevel. Must be one of: beginner, intermediate, advanced",
+        400,
+      );
+    }
+
     const updatedMember = await memberService.updateMember(
       req.params.id,
       filtered,

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,12 +1,14 @@
 import app from "./app";
 import { env } from "./config/env";
 if (!env.adminApiKey) {
-  console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
+  console.warn(
+    "WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.",
+  );
 }
 // if (!env.adminApiKey) {
 //   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
 //   process.exit(1)
-// } 
+// }
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,12 @@
 import app from "./app";
 import { env } from "./config/env";
-
+if (!env.adminApiKey) {
+  console.warn('WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.')
+}
+// if (!env.adminApiKey) {
+//   console.error('FATAL: ADMIN_API_KEY is not set. Refusing to start.')
+//   process.exit(1)
+// } 
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
Validates codingLevel against the allowed enum values (beginner, intermediate, advanced) before calling the service in updateMember, returning a 400 instead of letting Prisma throw a 500.

## Related issue

Closes #20 

## How did you test it?

<!-- Briefly: what you ran or clicked to confirm it works. -->

## Checklist

- [ ] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
