### PR TITLE
fix: Prevent empty strings for repoOwner (#17)

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -61,6 +61,10 @@ async function addProject(
 ) {
   if (!req.file) return response.failure(res, "Image file is required", 400);
 
+  if (req.body.repoOwner !== undefined && req.body.repoOwner.trim() === "") {
+    return response.failure(res, "repoOwner cannot be empty", 400);
+  }
+
   let publicId: string | undefined;
   try {
     const uploaded = await uploadBuffer(req.file.buffer, FOLDER);
@@ -109,7 +113,10 @@ async function updateProject(
     const data: Record<string, unknown> = {};
     const b = req.body;
     if (b.slug) data.slug = b.slug;
-    if (b.repoOwner) data.repoOwner = b.repoOwner;
+    if (b.repoOwner !== undefined) {
+      if (b.repoOwner.trim() === "") return response.failure(res, "repoOwner cannot be empty", 400);
+      data.repoOwner = b.repoOwner;
+    }
     if (b.repoName) data.repoName = b.repoName;
     if (b.tagline) data.tagline = b.tagline;
     if (b.category) data.category = b.category;


### PR DESCRIPTION
### Description
This pull request resolves **Issue #17**. 

Previously, the `POST /api/projects` and `PUT /api/projects/:id` endpoints permitted users to pass empty strings (`""`) or whitespace strings (`"   "`) for the `repoOwner` field. Because it was a string, it passed validation, but creating a project with a blank repository owner breaks downstream logic and GitHub API sync operations.

### Changes Made
- Modified `src/controllers/project.controller.ts` to explicitly block empty strings or whitespace.
- Added a `trim() === ""` check to both the `addProject` and `updateProject` endpoints specifically for `repoOwner`.
- If an empty string is detected, the API cleanly rejects the request and returns a `400 Bad Request` with the message `"repoOwner cannot be empty"`.

### Testing
- Tested locally to ensure that passing `""` or `"  "` to the `repoOwner` field correctly returns a `400` status.
