### PR TITLE
fix: Validate codingLevel enum in updateMember controller (#20)

### DIFF
--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -54,6 +54,13 @@ async function updateMember(
     const filtered = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<Omit<Member, "id">>;
+
+    if (
+      filtered.codingLevel !== undefined &&
+      !["beginner", "intermediate", "advanced"].includes(filtered.codingLevel)
+    ) {
+      return response.failure(res, "Invalid codingLevel value", 400);
+    }
     const updatedMember = await memberService.updateMember(
       req.params.id,
       filtered,


### PR DESCRIPTION
### Description
This pull request resolves **Issue #20**. 

Previously, when updating a member's details via `PUT /api/members/:id`, the controller did not validate if the provided `codingLevel` matched the valid enum values defined in the Prisma schema (`"beginner"`, `"intermediate"`, `"advanced"`). If a user provided an invalid string (e.g., `"expert"`), it would bypass the controller validation and crash the application with an unhandled database validation error (`500 Internal Server Error`).

### Changes Made
- Modified `src/controllers/member.controller.ts` inside the `updateMember` endpoint.
- Added explicit validation to verify if the provided `codingLevel` is part of the valid values: `["beginner", "intermediate", "advanced"]`.
- If an invalid value is supplied, the controller intercepts the request and returns a `400 Bad Request` with the message `"Invalid codingLevel value"`.

### Testing
- Tested locally to ensure standard enum options are updated successfully, while incorrect ones cleanly fail with a `400` status.
