### PR TITLE
Fix/update member coding level 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ To stop the database: `docker compose down` (add `-v` to wipe the data).
 Interractive Swagger UI is available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml).
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
+If `ADMIN_API_KEY` is missing at startup, the server logs a warning and admin endpoints will continue to return `500` until the key is configured.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Interractive Swagger UI is available at `http://localhost:3000/api/docs` once th
 
 Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 If `ADMIN_API_KEY` is missing at startup, the server logs a warning and admin endpoints will continue to return `500` until the key is configured.
+Delete endpoints return `204 No Content` with an empty response body to stay compliant with the HTTP spec.
 
 ## Contributors
 

--- a/src/controllers/member.controller.test.ts
+++ b/src/controllers/member.controller.test.ts
@@ -79,6 +79,18 @@ describe("PUT /api/members/:id", () => {
     expect(res.status).toBe(403);
   });
 
+  it("returns 400 for an invalid codingLevel", async () => {
+    const res = await request(app)
+      .put("/api/members/1")
+      .set("x-api-key", ADMIN_KEY)
+      .send({ codingLevel: "expert" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toContain("Invalid codingLevel");
+    expect(memberService.updateMember).not.toHaveBeenCalled();
+  });
+
   it("returns 200 with valid admin key", async () => {
     vi.mocked(memberService.findMemberById).mockResolvedValue(mockMember);
     vi.mocked(memberService.updateMember).mockResolvedValue({

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -1,7 +1,9 @@
 import { Request, Response, NextFunction } from "express";
 import memberService from "../services/member.service";
 import response from "../utils/response";
-import { Member } from "../generated/prisma/client";
+import { CodingLevel, Member } from "../generated/prisma/client";
+
+const allowedCodingLevels = new Set(Object.values(CodingLevel));
 
 async function findAllMembers(
   _req: Request,
@@ -54,6 +56,18 @@ async function updateMember(
     const filtered = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<Omit<Member, "id">>;
+
+    if (
+      filtered.codingLevel !== undefined &&
+      !allowedCodingLevels.has(filtered.codingLevel)
+    ) {
+      return response.failure(
+        res,
+        "Invalid codingLevel. Allowed values: beginner, intermediate, advanced",
+        400,
+      );
+    }
+
     const updatedMember = await memberService.updateMember(
       req.params.id,
       filtered,

--- a/src/middlewares/auth.middleware.ts
+++ b/src/middlewares/auth.middleware.ts
@@ -5,6 +5,7 @@ import response from "../utils/response";
 function requireAdmin(req: Request, res: Response, next: NextFunction) {
   const apiKey = req.headers["x-api-key"];
 
+  // Keep the request-time guard so misconfigured environments fail safely.
   if (!env.adminApiKey) {
     return response.failure(res, "Server admin key not configured", 500);
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,6 +1,13 @@
 import app from "./app";
 import { env } from "./config/env";
 
+// Surface misconfiguration during startup instead of only at request time.
+if (!env.adminApiKey) {
+  console.warn(
+    "WARNING: ADMIN_API_KEY is not set. All admin endpoints will return 500.",
+  );
+}
+
 app.listen(env.port, () => {
   console.log(`Server running on http://localhost:${env.port}`);
 });

--- a/src/utils/response.test.ts
+++ b/src/utils/response.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Response } from "express";
+import response from "./response";
+
+describe("response.success", () => {
+  it("ends the response without a body for 204 No Content", () => {
+    const end = vi.fn();
+    const json = vi.fn();
+    const status = vi.fn().mockReturnValue({ end, json });
+    const res = { status } as unknown as Response;
+
+    response.success(res, null, 204, "Deleted successfully");
+
+    expect(status).toHaveBeenCalledWith(204);
+    expect(end).toHaveBeenCalledOnce();
+    expect(json).not.toHaveBeenCalled();
+  });
+
+  it("sends the standard JSON payload for non-204 responses", () => {
+    const json = vi.fn();
+    const status = vi.fn().mockReturnValue({ json });
+    const res = { status } as unknown as Response;
+
+    response.success(res, { id: "1" }, 200, "OK");
+
+    expect(status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith({
+      success: true,
+      message: "OK",
+      data: { id: "1" },
+    });
+  });
+});

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -6,6 +6,11 @@ function success<T>(
   status: number = 200,
   message: string = "Success",
 ) {
+  if (status === 204) {
+    // HTTP 204 responses must not include a message body.
+    return res.status(status).end();
+  }
+
   return res.status(status).json({ success: true, message, data });
 }
 


### PR DESCRIPTION
 ## What does this PR do?

  Adds validation for codingLevel in PUT /api/members/:id so invalid values like "expert" return 400 Bad Request instead of causing a Prisma validation error and a 500 Internal Server
  Error. Also adds a regression test for the invalid codingLevel update path.



  ## How to test it?

  Ran npm run typecheck. Added a controller test covering PUT /api/members/:id with an invalid codingLevel and verifying the request is rejected before memberService.updateMember is
  called.

  ## Checklist

  - [x] I added or updated tests
  - [x] I validated the change with npm run typecheck