### PR TITLE
Added a guard before the addProject

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -67,6 +67,9 @@ async function addProject(
     publicId = uploaded.public_id;
 
     const featured = parseBoolean(req.body.featured) ?? false;
+    if (!req.body.repoOwner?.trim()) {
+      return response.failure(res, 'repoOwner is required', 400)
+    }
     const created = await projectService.addProject({
       slug: req.body.slug,
       repoOwner: req.body.repoOwner,


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

Add a guard at the top of addProject because it reads req.body.repoOwner and passes it directly to the service without checking it is non-empty. A project created with repoOwner: '' will always fail GitHub data fetching (the URL becomes /repos//repoName).

## Related issue

Closes #17

## How did you test it?

<!-- Briefly: what you ran or clicked to confirm it works. -->

## Checklist

- [x] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
