### PR TITLE
fix(member): add existence check before updating member

### DIFF
--- a/src/controllers/member.controller.test.ts
+++ b/src/controllers/member.controller.test.ts
@@ -73,10 +73,27 @@ describe("POST /api/members", () => {
 });
 
 describe("PUT /api/members/:id", () => {
+  beforeEach(() => {
+    vi.mocked(memberService.findMemberById).mockResolvedValue(mockMember);
+  });
+
   it("returns 403 without admin key", async () => {
     const res = await request(app).put("/api/members/1").send({ name: "Bob" });
 
     expect(res.status).toBe(403);
+  });
+
+  it("returns 404 when the member does not exist", async () => {
+    vi.mocked(memberService.findMemberById).mockResolvedValue(null);
+
+    const res = await request(app)
+      .put("/api/members/nonexistent")
+      .set("x-api-key", ADMIN_KEY)
+      .send({ name: "Bob" });
+
+    expect(res.status).toBe(404);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Member not found");
   });
 
   it("returns 400 for an invalid codingLevel", async () => {
@@ -92,7 +109,6 @@ describe("PUT /api/members/:id", () => {
   });
 
   it("returns 200 with valid admin key", async () => {
-    vi.mocked(memberService.findMemberById).mockResolvedValue(mockMember);
     vi.mocked(memberService.updateMember).mockResolvedValue({
       ...mockMember,
       name: "Bob",

--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -53,6 +53,9 @@ async function updateMember(
   next: NextFunction,
 ) {
   try {
+    const existing = await memberService.findMemberById(req.params.id);
+    if (!existing) return response.failure(res, "Member not found", 404);
+
     const filtered = Object.fromEntries(
       Object.entries(req.body).filter(([, v]) => v !== ""),
     ) as Partial<Omit<Member, "id">>;


### PR DESCRIPTION
## What does this PR do?

Adds an existence check at the top of `updateMember` in `src/controllers/member.controller.ts`. Previously, a missing ID fell through to Prisma's P2025 error → generic `"Record not found"` 404. Now it explicitly returns `404 "Member not found"`, matching `updateEvent`, `updatePartner`, and `updateProject`.

## Related issue

Closes #

## How did you test it?

`PUT /api/members/<non-existent-id>` now returns `404 Member not found`. All 17 tests pass.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed