### PR TITLE
fix: validate email format on member creation endpoint

### DIFF
--- a/src/controllers/member.controller.ts
+++ b/src/controllers/member.controller.ts
@@ -40,6 +40,10 @@ async function addMember(
   next: NextFunction,
 ) {
   try {
+    const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!EMAIL_RE.test(req.body.email)) {
+      return response.failure(res, 'Invalid email address', 400)
+    }
     const newMember = await memberService.addMember(req.body);
     response.success(res, newMember, 201, "Member created successfully");
   } catch (err) {


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

I successfully added a valid email checker to the add member creation endpoint

## Related issue

Closes #15

## How did you test it?

i used the swagger UI and sent a API request test with an invalid email field and got a 400 error "invalid email" and then corrected the email and got the 201 response with "member created"

## Checklist

- [x] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
