### PR TITLE
added feature for getting project by id

### DIFF
--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -41,6 +41,22 @@ async function findProjectBySlug(
   }
 }
 
+async function findProjectById(
+  req: Request<{ id: string }>,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const project = await projectService.findProjectById(req.params.id);
+
+    if (!project) return response.failure(res, "Project not found", 404);
+
+    response.success(res, project, 200, "Project retrieved successfully");
+  } catch (err) {
+    next(err);
+  }
+}
+
 async function addProject(req: Request, res: Response, next: NextFunction) {
   if (!req.file) return response.failure(res, "Image file is required", 400);
 
@@ -192,4 +208,5 @@ export default {
   updateProject,
   deleteProject,
   refreshAll,
+  findProjectById,
 };

--- a/src/routes/project.routes.ts
+++ b/src/routes/project.routes.ts
@@ -7,6 +7,7 @@ const route = Router();
 
 route.get("/", projectController.findAllProjects);
 route.get("/:slug", projectController.findProjectBySlug);
+route.get("/id/:id", projectController.findProjectById);
 
 route.use(authMiddleware.requireAdmin);
 route.post("/refresh", projectController.refreshAll);


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

Adds a dedicated endpoint for fetching a project by ID using `/api/projects/id/:id`, while keeping slug based project lookup available.

## Related issue

Closes #48

## How did you test it?

Tested manually by calling:

`GET http://localhost:3000/api/projects/id/892b9cd9-009f-437d-a158-16f93589a4b2`

## Checklist

- [ ] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed