### PR TITLE
docs: fix Swagger UI typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Build with Express, TypeScript, Prisma, and PostgreSQL.
 - **Language:** TypeScript (strict mode)
 - **Database:** PostgreSQL via Prisma
 - **Image storage:** Cloudinary
-- **API docs:** OpenAPI served trough Swagger UI
+- **API docs:** OpenAPI served through Swagger UI
 
 ## Getting started
 


### PR DESCRIPTION
## Problem

The README tech stack section says OpenAPI is served `trough` Swagger UI. This is a visible typo in the first documentation section new contributors read.

## Root Cause

The intended word is `through`, but the README contains the misspelling `trough`.

## What Changed

- Replaced `trough Swagger UI` with `through Swagger UI` in `README.md`.

## Why This Approach

The issue asks for a focused documentation correction, so the PR changes only the affected word and leaves the rest of the README untouched.

## Validation

- `git diff --check`
- `rg "trough|through" README.md`

## Risk

Very low. Documentation-only typo fix.

Closes #38
