### PR TITLE
docs: fix Conventional Commits typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ We use a three-branch flow: `dev` → `staging` → `main`.
 
 ## Commit messages
 
-We use [Convential Commits](https://www.conventionalcommits.org/). The first line should be:
+We use [Conventional Commits](https://www.conventionalcommits.org/). The first line should be:
 
 ```
 <type>: <short summary>


### PR DESCRIPTION
## Problem

The CONTRIBUTING guide links to the Conventional Commits standard, but the link text currently says `Convential Commits`.

## Root Cause

This is a spelling mistake in the commit message guidance. The URL is correct, but the displayed standard name is misspelled.

## What Changed

- Replaced `Convential Commits` with `Conventional Commits` in `CONTRIBUTING.md`.

## Why This Approach

The issue asks for a focused typo fix. This keeps the PR limited to the exact documentation defect and avoids unrelated wording changes.

## Validation

- `git diff --check`
- `rg "Convential|Conventional" CONTRIBUTING.md`

## Risk

Very low. Documentation-only typo fix.

Closes #40
