### PR TITLE
Sort members by creation date

### DIFF
--- a/src/services/member.service.test.ts
+++ b/src/services/member.service.test.ts
@@ -33,7 +33,9 @@ describe("findAllMembers", () => {
 
     const result = await memberService.findAllMembers();
 
-    expect(prismaMock.member.findMany).toHaveBeenCalledOnce();
+    expect(prismaMock.member.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+    });
     expect(result).toEqual([mockMember]);
   });
 });

--- a/src/services/member.service.ts
+++ b/src/services/member.service.ts
@@ -2,7 +2,9 @@ import { prisma } from "../config/prisma";
 import { Member } from "../generated/prisma/client";
 
 async function findAllMembers() {
-  return prisma.member.findMany();
+  return prisma.member.findMany({
+    orderBy: { createdAt: "desc" },
+  });
 }
 
 async function addMember(


### PR DESCRIPTION
## Summary
- add a stable default sort order for member listings
- update the member service test to verify the Prisma query

Closes #12

## Tests
- npm test -- src/services/member.service.test.ts
- npm run typecheck
- npm run lint
- npm test