### PR TITLE
Validate event capacity on update

### DIFF
--- a/src/controllers/event.controller.test.ts
+++ b/src/controllers/event.controller.test.ts
@@ -5,6 +5,8 @@ import app from "../app";
 vi.mock("../services/event.service");
 import eventService from "../services/event.service";
 
+const ADMIN_KEY = "test-admin-key";
+
 const mockEvent = {
   id: "1",
   title: "OSK Meetup",
@@ -51,5 +53,23 @@ describe("GET /api/events", () => {
     expect(vi.mocked(eventService.findAllEvents)).toHaveBeenCalledWith(
       undefined,
     );
+  });
+});
+
+describe("PUT /api/events/:id", () => {
+  it("returns 400 when registered would exceed capacity", async () => {
+    vi.mocked(eventService.findEventById).mockResolvedValue(mockEvent);
+
+    const res = await request(app)
+      .put("/api/events/1")
+      .set("x-api-key", ADMIN_KEY)
+      .send({
+        registered: 101,
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.success).toBe(false);
+    expect(res.body.message).toBe("Registered count cannot exceed capacity");
+    expect(vi.mocked(eventService.updateEvent)).not.toHaveBeenCalled();
   });
 });

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -107,6 +107,23 @@ async function updateEvent(
       Object.entries(data).filter(([, v]) => v !== "" && v !== undefined),
     ) as Prisma.EventUpdateInput;
 
+    const nextCapacity =
+      data.capacity !== undefined ? data.capacity : existing.capacity;
+    const nextRegistered =
+      data.registered !== undefined ? data.registered : existing.registered;
+
+    if (
+      typeof nextCapacity === "number" &&
+      typeof nextRegistered === "number" &&
+      nextRegistered > nextCapacity
+    ) {
+      return response.failure(
+        res,
+        "Registered count cannot exceed capacity",
+        400,
+      );
+    }
+
     if (req.file) {
       const uploaded = await uploadBuffer(req.file.buffer, FOLDER);
       newPublicId = uploaded.public_id;


### PR DESCRIPTION
## Summary
- reject event updates where the resulting registered count exceeds capacity
- compare partial update data against the existing event values
- add a controller regression test

Closes #28

## Tests
- npm test -- src/controllers/event.controller.test.ts
- npm run typecheck
- npm run lint
- npm test