### PR TITLE
Improve GitHub API 403 errors

### DIFF
--- a/src/services/github.service.test.ts
+++ b/src/services/github.service.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GitHubError, gh } from "./github.service";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("gh", () => {
+  it("throws a rate limit hint for exhausted GitHub API quota", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("API rate limit exceeded", {
+          status: 403,
+          headers: { "x-ratelimit-remaining": "0" },
+        }),
+      ),
+    );
+
+    await expect(gh("/repos/org/repo")).rejects.toMatchObject({
+      name: "GitHubError",
+      status: 403,
+      message: expect.stringContaining("GitHub rate limit exceeded"),
+    });
+  });
+
+  it("keeps the status and response body for non-rate-limit errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("Not Found", { status: 404 })),
+    );
+
+    await expect(gh("/repos/org/missing")).rejects.toEqual(
+      new GitHubError(404, "GitHub 404 on /repos/org/missing: Not Found"),
+    );
+  });
+});

--- a/src/services/github.service.ts
+++ b/src/services/github.service.ts
@@ -37,9 +37,22 @@ export class GitHubError extends Error {
 export async function gh(path: string) {
   const res = await fetch(`${API}${path}`, { headers: headers() });
   if (!res.ok) {
+    const body = await res.text();
+    if (res.status === 403) {
+      const remaining = res.headers.get("x-ratelimit-remaining");
+      const rateLimitMessage =
+        remaining === "0"
+          ? "GitHub rate limit exceeded. Set GITHUB_TOKEN to increase your limit."
+          : "GitHub request forbidden. Check GITHUB_TOKEN permissions or rate limits.";
+      throw new GitHubError(
+        res.status,
+        `${rateLimitMessage} GitHub 403 on ${path}: ${body}`,
+      );
+    }
+
     throw new GitHubError(
       res.status,
-      `GitHub ${res.status} on ${path}: ${await res.text()}`,
+      `GitHub ${res.status} on ${path}: ${body}`,
     );
   }
   return res;


### PR DESCRIPTION
## Summary
- add a specific message for exhausted GitHub API quota
- keep the status and response body in thrown GitHubError messages
- add tests for rate-limit and generic error responses

Closes #29

## Tests
- npm test -- src/services/github.service.test.ts
- npm run typecheck
- npm run lint
- npm test