### PR TITLE
Reject blank project repository names

### DIFF
--- a/src/schemas/project.schema.test.ts
+++ b/src/schemas/project.schema.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { createProjectSchema } from "./project.schema";
+
+const validProject = {
+  slug: "osk-backend",
+  repoOwner: "Open-Source-Kigali",
+  repoName: "osk-backend",
+  tagline: "Open source community backend",
+  category: "community",
+};
+
+describe("createProjectSchema", () => {
+  it("rejects whitespace-only repository names", () => {
+    const result = createProjectSchema.safeParse({
+      ...validProject,
+      repoName: "   ",
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues[0].path).toEqual(["repoName"]);
+  });
+
+  it("trims project fields before validation", () => {
+    const result = createProjectSchema.parse({
+      ...validProject,
+      slug: " osk-backend ",
+      repoOwner: " Open-Source-Kigali ",
+      repoName: " osk-backend ",
+      tagline: " Open source community backend ",
+      category: " community ",
+    });
+
+    expect(result).toMatchObject(validProject);
+  });
+});

--- a/src/schemas/project.schema.ts
+++ b/src/schemas/project.schema.ts
@@ -3,22 +3,22 @@ import { z } from "zod";
 export const createProjectSchema = z.object({
   slug: z
     .string()
+    .trim()
     .min(1, "Slug is required")
     .regex(
       /^[a-z0-9]+(?:-[a-z0-9]+)*$/,
       "Slug must be lowercase with hyphens only, no spaces or special characters",
-    )
-    .trim(),
+    ),
   repoOwner: z
     .string()
-    .min(1, "Repository owner is required and cannot be empty")
-    .trim(),
+    .trim()
+    .min(1, "Repository owner is required and cannot be empty"),
   repoName: z
     .string()
-    .min(1, "Repository name is required and cannot be empty")
-    .trim(),
-  tagline: z.string().min(1, "Tagline is required").trim(),
-  category: z.string().min(1, "Category is required").trim(),
+    .trim()
+    .min(1, "Repository name is required and cannot be empty"),
+  tagline: z.string().trim().min(1, "Tagline is required"),
+  category: z.string().trim().min(1, "Category is required"),
   status: z
     .enum(["active", "archived", "paused"] as const)
     .optional()


### PR DESCRIPTION
## Summary
- trim required project fields before validating minimum length
- reject whitespace-only repoName/repoOwner values before they reach GitHub API calls
- add schema tests for blank and trimmed inputs

Closes #18

## Tests
- npm test -- src/schemas/project.schema.test.ts
- npm run typecheck
- npm run lint
- npm test