### PR TITLE
Hide Cloudinary public IDs from public responses

### DIFF
--- a/src/controllers/event.controller.test.ts
+++ b/src/controllers/event.controller.test.ts
@@ -38,6 +38,7 @@ describe("GET /api/events", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).not.toHaveProperty("imagePublicId");
     expect(vi.mocked(eventService.findAllEvents)).toHaveBeenCalledWith(true);
   });
 

--- a/src/controllers/event.controller.ts
+++ b/src/controllers/event.controller.ts
@@ -3,6 +3,7 @@ import eventService from "../services/event.service";
 import response from "../utils/response";
 import { Event, Prisma } from "../generated/prisma/client";
 import { destroyImage, uploadBuffer } from "../utils/cloudinary-upload";
+import stripPublicIds from "../utils/strip-public-ids";
 import { parseRequestBody } from "../utils/validation";
 import {
   createEventSchema,
@@ -19,7 +20,12 @@ async function findAllEvents(_req: Request, res: Response, next: NextFunction) {
   try {
     const featured = _req.query.featured === "true" ? true : undefined;
     const allEvents = await eventService.findAllEvents(featured);
-    response.success(res, allEvents, 200, "Events retrieved successfully");
+    response.success(
+      res,
+      stripPublicIds(allEvents),
+      200,
+      "Events retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }
@@ -35,7 +41,12 @@ async function findEventById(
     if (!event) {
       return response.failure(res, "Event not found", 404);
     }
-    return response.success(res, event, 200, "Event retrieved successfully");
+    return response.success(
+      res,
+      stripPublicIds(event),
+      200,
+      "Event retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }

--- a/src/controllers/partner.controllers.ts
+++ b/src/controllers/partner.controllers.ts
@@ -3,6 +3,7 @@ import partnerService from "../services/partner.service";
 import response from "../utils/response";
 import { Partner } from "../generated/prisma/client";
 import { destroyImage, uploadBuffer } from "../utils/cloudinary-upload";
+import stripPublicIds from "../utils/strip-public-ids";
 import trimStrings from "../utils/trim-strings";
 import { parseRequestBody } from "../utils/validation";
 import {
@@ -20,7 +21,12 @@ async function findAllPartners(
 ) {
   try {
     const allPartners = await partnerService.findAllPartners();
-    response.success(res, allPartners, 200, "Partners retrieved successfully");
+    response.success(
+      res,
+      stripPublicIds(allPartners),
+      200,
+      "Partners retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }
@@ -38,7 +44,7 @@ async function findPartnerById(
     }
     return response.success(
       res,
-      partner,
+      stripPublicIds(partner),
       200,
       "Partner retrieved successfully",
     );

--- a/src/controllers/project.controller.test.ts
+++ b/src/controllers/project.controller.test.ts
@@ -44,6 +44,7 @@ describe("GET /api/projects", () => {
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
     expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).not.toHaveProperty("imagePublicId");
     expect(vi.mocked(projectService.findAllProjects)).toHaveBeenCalledWith(
       true,
     );

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -3,6 +3,7 @@ import projectService from "../services/project.service";
 import response from "../utils/response";
 import { destroyImage, uploadBuffer } from "../utils/cloudinary-upload";
 import { fetchRepoSnapshot } from "../services/github.service";
+import stripPublicIds from "../utils/strip-public-ids";
 import trimStrings from "../utils/trim-strings";
 import { parseRequestBody } from "../utils/validation";
 import {
@@ -22,7 +23,12 @@ async function findAllProjects(
   try {
     const featured = _req.query.featured === "true" ? true : undefined;
     const projects = await projectService.findAllProjects(featured);
-    response.success(res, projects, 200, "Projects retrieved successfully");
+    response.success(
+      res,
+      stripPublicIds(projects),
+      200,
+      "Projects retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }
@@ -36,7 +42,12 @@ async function findProjectBySlug(
   try {
     const project = await projectService.findProjectBySlug(req.params.slug);
     if (!project) return response.failure(res, "Project not found", 404);
-    response.success(res, project, 200, "Project retrieved successfully");
+    response.success(
+      res,
+      stripPublicIds(project),
+      200,
+      "Project retrieved successfully",
+    );
   } catch (err) {
     next(err);
   }

--- a/src/utils/strip-public-ids.test.ts
+++ b/src/utils/strip-public-ids.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import stripPublicIds from "./strip-public-ids";
+
+describe("stripPublicIds", () => {
+  it("removes internal Cloudinary public ids from response objects", () => {
+    expect(
+      stripPublicIds({
+        imageUrl: "https://example.com/image.jpg",
+        imagePublicId: "internal-image-id",
+        logoPublicId: "internal-logo-id",
+        profilePublicId: "internal-profile-id",
+      }),
+    ).toEqual({
+      imageUrl: "https://example.com/image.jpg",
+    });
+  });
+
+  it("removes internal public ids from arrays", () => {
+    expect(
+      stripPublicIds([
+        { name: "Event", imagePublicId: "event-id" },
+        { name: "Partner", logoPublicId: "logo-id" },
+      ]),
+    ).toEqual([{ name: "Event" }, { name: "Partner" }]);
+  });
+});

--- a/src/utils/strip-public-ids.ts
+++ b/src/utils/strip-public-ids.ts
@@ -1,0 +1,21 @@
+const INTERNAL_PUBLIC_ID_KEYS = new Set([
+  "imagePublicId",
+  "logoPublicId",
+  "profilePublicId",
+]);
+
+function stripPublicIds<T>(value: T): T {
+  if (Array.isArray(value)) {
+    return value.map(stripPublicIds) as T;
+  }
+
+  if (!value || typeof value !== "object" || value instanceof Date) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => !INTERNAL_PUBLIC_ID_KEYS.has(key)),
+  ) as T;
+}
+
+export default stripPublicIds;


### PR DESCRIPTION
## Summary
- remove internal Cloudinary public IDs from public event, partner, and project GET responses
- keep admin mutation behavior unchanged so old images can still be deleted
- add utility and endpoint regression tests

Closes #23

## Tests
- npm test -- src/utils/strip-public-ids.test.ts src/controllers/event.controller.test.ts src/controllers/project.controller.test.ts
- npm run typecheck
- npm run lint
- npm test