### PR TITLE
feat: add GET /api/stats endpoint

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -20,6 +20,7 @@ tags:
   - name: Contributors
   - name: Reviews
   - name: Users
+  - name: Stats
 
 paths:
   /health:
@@ -687,6 +688,32 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
+        "500": { $ref: "#/components/responses/InternalError" }
+
+  /stats:
+    get:
+      tags: [Stats]
+      summary: Fetch community stats
+      responses:
+        "200":
+          description: Stats fetched successfully
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiSuccess"
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          contributors: { type: number }
+                          members: { type: number }
+                          projects: { type: number }
+                          events: { type: number }
+                          partners: { type: number }
+                          reviews: { type: number }
+                          pullRequests: { type: number }
         "500": { $ref: "#/components/responses/InternalError" }
 
 components:

--- a/src/controllers/stats.controller.test.ts
+++ b/src/controllers/stats.controller.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import request from "supertest";
+import app from "../app";
+
+vi.mock("../services/stats.service");
+import statsService from "../services/stats.service";
+
+beforeEach(() => vi.resetAllMocks());
+
+describe("GET /api/stats", () => {
+  it("returns 200 with the correct stats shape", async () => {
+    const mockData = {
+      contributors: 12,
+      members: 1500,
+      projects: 10,
+      events: 4,
+      partners: 6,
+      reviews: 5,
+      pullRequests: 25,
+    };
+
+    vi.mocked(statsService.getStats).mockResolvedValue(mockData);
+
+    const res = await request(app).get("/api/stats");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.message).toBe("Stats fetched successfully");
+    expect(res.body.data).toEqual(mockData);
+  });
+});

--- a/src/controllers/stats.controller.ts
+++ b/src/controllers/stats.controller.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction } from "express";
+import statsService from "../services/stats.service";
+
+export async function getStats(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
+  try {
+    const data = await statsService.getStats();
+
+    res.status(200).json({
+      success: true,
+      message: "Stats fetched successfully",
+      data,
+    });
+  } catch (error) {
+    next(error);
+  }
+}
+
+export default {
+  getStats,
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@ import eventRoutes from "./event.routes";
 import projectRoutes from "./project.routes";
 import reviewRoutes from "./review.routes";
 import contributorsRoutes from "./contributors.routes";
+import statsRoutes from "./stats.routes";
 
 const router = Router();
 
@@ -16,5 +17,6 @@ router.use("/events", eventRoutes);
 router.use("/projects", projectRoutes);
 router.use("/reviews", reviewRoutes);
 router.use("/contributors", contributorsRoutes);
+router.use("/stats", statsRoutes);
 
 export default router;

--- a/src/routes/stats.routes.ts
+++ b/src/routes/stats.routes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import statsController from "../controllers/stats.controller";
+
+const router = Router();
+
+router.get("/", statsController.getStats);
+
+export default router;

--- a/src/services/stats.service.ts
+++ b/src/services/stats.service.ts
@@ -1,0 +1,31 @@
+import { prisma } from "../config/prisma";
+import { readContributors } from "./contributors.service";
+
+async function getStats() {
+  const [members, projects, events, partners, reviews, prAggregate] =
+    await prisma.$transaction([
+      prisma.member.count(),
+      prisma.project.count(),
+      prisma.event.count(),
+      prisma.partner.count(),
+      prisma.review.count(),
+      prisma.project.aggregate({ _sum: { ghPullRequests: true } }),
+    ]);
+
+  const contributorsData = await readContributors();
+  const contributors = contributorsData.length;
+
+  return {
+    contributors,
+    members,
+    projects,
+    events,
+    partners,
+    reviews,
+    pullRequests: prAggregate._sum.ghPullRequests || 0,
+  };
+}
+
+export default {
+  getStats,
+};


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

<!-- 1-2 sentences describing your change. -->
This PR adds the `GET /api/stats` endpoint which fetches and calculates live community stats from the database to replace the hardcoded values on the frontend. It includes a new service using a Prisma transaction, a controller, route registration, and updates to the OpenAPI documentation.

## Related issue

Closes #193

## How did you test it?

<!-- Briefly: what you ran or clicked to confirm it works. -->
Added unit tests in `src/controllers/stats.controller.test.ts` to verify the controller returns the correct shape and mock data. Verified everything works by running `npx vitest run src/controllers/stats.controller.test.ts` and ensuring all local checks pass.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed