### PR TITLE
feat: add category filter support for GET /projects (#260)

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -377,6 +377,14 @@ paths:
     get:
       tags: [Projects]
       summary: List all projects
+      parameters:
+        - name: category
+          in: query
+          required: false
+          schema:
+            type: string
+            example: education
+          description: Filter projects by category. When provided, only projects in the selected category are returned.
       responses:
         "200":
           description: Projects retrieved successfully
@@ -390,6 +398,23 @@ paths:
                       data:
                         type: array
                         items: { $ref: "#/components/schemas/Project" }
+              examples:
+                allProjects:
+                  summary: All projects
+                  value:
+                    success: true
+                    message: Projects retrieved successfully
+                    data:
+                      - slug: osk-backend
+                        category: backend
+                filteredByCategory:
+                  summary: Projects filtered by category
+                  value:
+                    success: true
+                    message: Projects retrieved successfully
+                    data:
+                      - slug: osk-backend
+                        category: education
         "500": { $ref: "#/components/responses/InternalError" }
     post:
       tags: [Projects]

--- a/src/controllers/project.controller.test.ts
+++ b/src/controllers/project.controller.test.ts
@@ -46,18 +46,43 @@ describe("GET /api/projects", () => {
     expect(res.body.data).toHaveLength(1);
     expect(vi.mocked(projectService.findAllProjects)).toHaveBeenCalledWith(
       true,
+      undefined,
     );
   });
 
-  it("returns 200 and fetches all projects when featured is not provided", async () => {
+  it("returns 200 and fetches all projects when no category filter is provided", async () => {
     vi.mocked(projectService.findAllProjects).mockResolvedValue([mockProject]);
 
     const res = await request(app).get("/api/projects");
 
     expect(res.status).toBe(200);
     expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      slug: mockProject.slug,
+      category: mockProject.category,
+    });
     expect(vi.mocked(projectService.findAllProjects)).toHaveBeenCalledWith(
       undefined,
+      undefined,
+    );
+  });
+
+  it("returns 200 and forwards the category filter to the service", async () => {
+    vi.mocked(projectService.findAllProjects).mockResolvedValue([mockProject]);
+
+    const res = await request(app).get("/api/projects?category=education");
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.data).toHaveLength(1);
+    expect(res.body.data[0]).toMatchObject({
+      slug: mockProject.slug,
+      category: mockProject.category,
+    });
+    expect(vi.mocked(projectService.findAllProjects)).toHaveBeenCalledWith(
+      undefined,
+      "education",
     );
   });
 });

--- a/src/controllers/project.controller.ts
+++ b/src/controllers/project.controller.ts
@@ -15,13 +15,33 @@ import {
 const FOLDER = "open-source-kigali/projects";
 
 async function findAllProjects(
-  _req: Request,
+  req: Request,
   res: Response,
   next: NextFunction,
 ) {
   try {
-    const featured = _req.query.featured === "true" ? true : undefined;
-    const projects = await projectService.findAllProjects(featured);
+    const featured = req.query.featured === "true" ? true : undefined;
+    const categoryQuery = req.query.category;
+
+    let category: string | undefined;
+    if (categoryQuery !== undefined) {
+      if (typeof categoryQuery !== "string") {
+        return response.failure(res, "category must be a string", 400);
+      }
+
+      const trimmedCategory = categoryQuery.trim();
+      if (!trimmedCategory) {
+        return response.failure(
+          res,
+          "category must be a non-empty string",
+          400,
+        );
+      }
+
+      category = trimmedCategory;
+    }
+
+    const projects = await projectService.findAllProjects(featured, category);
     response.success(res, projects, 200, "Projects retrieved successfully");
   } catch (err) {
     next(err);

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -2,9 +2,19 @@ import { prisma } from "../config/prisma";
 import { Prisma, Project } from "../generated/prisma/client";
 import { RepoSnapshot } from "./github.service";
 
-async function findAllProjects(featured?: boolean) {
+async function findAllProjects(featured?: boolean, category?: string) {
+  const where: Prisma.ProjectWhereInput = {};
+
+  if (featured !== undefined) {
+    where.featured = featured;
+  }
+
+  if (category) {
+    where.category = { equals: category, mode: "insensitive" };
+  }
+
   return prisma.project.findMany({
-    where: featured !== undefined ? { featured } : undefined,
+    where: Object.keys(where).length > 0 ? where : undefined,
     orderBy: { createdAt: "desc" },
     omit: { imagePublicId: true },
   });


### PR DESCRIPTION
## What does this PR do?

Adds support for filtering projects by category using the `?category=` query parameter on the GET /projects endpoint.

## Related issue

Closes #260

## How did you test it?

Tested manually using curl:
- GET /api/projects → returns all projects
- GET /api/projects?category=Backend → returns only Backend projects
- GET /api/projects?category=NonExistent → returns empty array

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed