### PR TITLE
fix slug not working

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -588,7 +588,7 @@ paths:
         "403": { $ref: "#/components/responses/Forbidden" }
         "500": { $ref: "#/components/responses/InternalError" }
 
-  /projects/{slug}:
+  /projects/slug/{slug}:
     parameters:
       - in: path
         name: slug

--- a/src/routes/project.routes.ts
+++ b/src/routes/project.routes.ts
@@ -7,7 +7,7 @@ const route = Router();
 
 route.get("/", projectController.findAllProjects);
 route.get("/:id", projectController.findProjectById);
-route.get("/:slug", projectController.findProjectBySlug);
+route.get("/slug/:slug", projectController.findProjectBySlug);
 
 route.use(authMiddleware.requireAdmin);
 route.post("/refresh", projectController.refreshAll);


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

This PR updates the project slug route from:/:slug to /slug/:slug

## Related issue

Closes #281

## How did you test it?

I did run typ checking and i had no seedings to test projects but the issue was self explanatory i beleive the change adddressed it 

## Checklist

- [yes ] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ yes] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
