### PR TITLE
Feat: fetch feature review

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -896,6 +896,7 @@ components:
         profilePublicId: { type: string }
         role: { type: string }
         message: { type: string }
+        featured: { type: boolean }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 

--- a/prisma/migrations/20260729174941_add_featured_field_in_review_model/migration.sql
+++ b/prisma/migrations/20260729174941_add_featured_field_in_review_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "featured" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Review {
   profilePublicId String
   role            String
   message         String
+  featured      Boolean   @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -7,13 +7,10 @@ import trimStrings from "../utils/trim-strings";
 
 type ReviewBody = Omit<Review, "id" | "createdAt" | "updatedAt">;
 
-async function findAllReviews(
-  _req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+async function findAllReviews(req: Request, res: Response, next: NextFunction) {
   try {
-    const reviews = await reviewService.findAllReviews();
+    const featured = req.query["featured"] ? true : undefined;
+    const reviews = await reviewService.findAllReviews(featured);
     response.success(res, reviews, 200, "Reviews retrieved successfully");
   } catch (err) {
     next(err);

--- a/src/services/review.service.test.ts
+++ b/src/services/review.service.test.ts
@@ -1,0 +1,74 @@
+import { PrismaClient } from "@prisma/client/extension";
+import { beforeEach, it, vi, describe, expect } from "vitest";
+import { DeepMockProxy, mockReset } from "vitest-mock-extended";
+vi.mock("../config/prisma", async () => {
+  const { mockDeep } = await import("vitest-mock-extended");
+  return { prisma: mockDeep<PrismaClient>() };
+});
+import { prisma } from "../config/prisma";
+import reviewService from "./review.service";
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+const mockReviews = [
+  {
+    id: "4",
+    name: "Arnold jabo",
+    profileUrl: "https://images.com/456",
+    profilePublickId: "43",
+    role: "user",
+    message: "some random messages",
+    featured: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "40",
+    name: "John Doe",
+    profileUrl: "https://images.com/400",
+    profilePublickId: "47",
+    role: "user",
+    message: "Lorem ipsum lorem ipsum",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "50",
+    name: "jane doe",
+    profileUrl: "https://images.com/600",
+    profilePublickId: "73",
+    role: "user",
+    message: "Great Job!",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+beforeEach(() => mockReset(prismaMock));
+
+describe("fetching reviews", () => {
+  it("returns all reviews", async () => {
+    prismaMock.review.findMany.mockResolvedValue(mockReviews);
+    const results = await reviewService.findAllReviews();
+    expect(prismaMock.review.findMany).toHaveBeenCalled();
+    expect(results).toEqual(mockReviews);
+  });
+
+  it("returns only featured reviews", async () => {
+    const featuredReviews = mockReviews.filter(
+      (review) => review.featured === true,
+    );
+    prismaMock.review.findMany.mockResolvedValue(featuredReviews);
+    const results = await reviewService.findAllReviews(true);
+    expect(prismaMock.review.findMany).toHaveBeenCalled();
+    expect(results).toEqual(featuredReviews);
+  });
+
+  it("returns all revies when featured flag is undfined", async () => {
+    prismaMock.review.findMany.mockResolvedValue(mockReviews);
+    const results = await reviewService.findAllReviews(undefined);
+    expect(prismaMock.review.findMany).toHaveBeenCalled();
+    expect(results).toEqual(mockReviews);
+  });
+});

--- a/src/services/review.service.test.ts
+++ b/src/services/review.service.test.ts
@@ -1,10 +1,13 @@
 import { PrismaClient } from "@prisma/client/extension";
-import { beforeEach, it, vi, describe, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+import { Review } from "../generated/prisma/client";
 import { DeepMockProxy, mockReset } from "vitest-mock-extended";
+
 vi.mock("../config/prisma", async () => {
   const { mockDeep } = await import("vitest-mock-extended");
   return { prisma: mockDeep<PrismaClient>() };
 });
+
 import { prisma } from "../config/prisma";
 import reviewService from "./review.service";
 
@@ -47,12 +50,26 @@ const mockReviews = [
 
 beforeEach(() => mockReset(prismaMock));
 
-describe("fetching reviews", () => {
-  it("returns all reviews", async () => {
+describe("Review Service - findAllReviews", () => {
+  it("should return newest reviews first", async () => {
+    const mockReviews = [
+      {
+        id: "1",
+        createdAt: new Date("2026-01-02"),
+      },
+      {
+        id: "2",
+        createdAt: new Date("2026-01-01"),
+      },
+    ] as Review[];
+
     prismaMock.review.findMany.mockResolvedValue(mockReviews);
-    const results = await reviewService.findAllReviews();
-    expect(prismaMock.review.findMany).toHaveBeenCalled();
-    expect(results).toEqual(mockReviews);
+
+    const reviews = await reviewService.findAllReviews();
+
+    expect(reviews[0].createdAt.getTime()).toBeGreaterThan(
+      reviews[1].createdAt.getTime(),
+    );
   });
 
   it("returns only featured reviews", async () => {

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -4,7 +4,7 @@ import { Review } from "../generated/prisma/client";
 async function findAllReviews(featuredReviews?: boolean): Promise<Review[]> {
   return prisma.review.findMany({
     where: { featured: featuredReviews },
-    orderBy: { createdAt: "asc" },
+    orderBy: { createdAt: "desc" },
   });
 }
 

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -1,8 +1,11 @@
 import { prisma } from "../config/prisma";
 import { Review } from "../generated/prisma/client";
 
-async function findAllReviews(): Promise<Review[]> {
-  return prisma.review.findMany({ orderBy: { createdAt: "asc" } });
+async function findAllReviews(featuredReviews?: boolean): Promise<Review[]> {
+  return prisma.review.findMany({
+    where: { featured: featuredReviews },
+    orderBy: { createdAt: "asc" },
+  });
 }
 
 async function findReviewById(id: string): Promise<Review | null> {


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
The PR fetches reviews with the featured field set to true in the request query parameter and fetches all reviews when the query parameter is not provided

## Related issue

Closes #296 

## How did you test it?
I have created a unit test for `findAllReviews` function in the review services to test whether it returns reviews that have true on featured field or if there is no params it fetches all reviews, whether featured or not

## Database change
- Added a `featured` Boolean field to the `Review` model in `prisma/schema.prisma`.
- Default value is `false`.
- This enables filtering reviews by featured status (e.g., return only featured reviews when needed).
- Data implication: existing reviews will have `featured = false` by default unless explicitly updated.


## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [x] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed

<img width="887" height="402" alt="Screenshot 2026-07-29 184936" src="https://github.com/user-attachments/assets/db9807c1-17df-490c-b738-7b0a6a48d4e0" />

<img width="1832" height="948" alt="image" src="https://github.com/user-attachments/assets/03979535-a229-4f76-af92-6ab9e32f981d" />

