### PR TITLE
fix[middleware] :return 404 for the non-existing routes

### DIFF
--- a/src/middlewares/not-found.middleware.test.ts
+++ b/src/middlewares/not-found.middleware.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import request from "supertest";
+import app from "../app";
+
+describe("Not Found Middleware", () => {
+  it("returns status 404 when calling a non-existent URL", async () => {
+    const res = await request(app).get("/api/this-does-not-exist");
+
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/middlewares/not-found.middleware.ts
+++ b/src/middlewares/not-found.middleware.ts
@@ -2,5 +2,5 @@ import { Request, Response } from "express";
 import response from "../utils/response";
 
 export function notFound(_req: Request, res: Response) {
-  response.failure(res, "Not Found", 400);
+  response.failure(res, "Not Found", 404);
 }


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?

Fixes the notFound middleware to return HTTP status 404 instead of 400 when calling non-existent routes, and adds a unit test to verify this behavior.

## Related issue

Closes #274 

## How did you test it?

Added a unit test using supertest in src/middlewares/not-found.middleware.test.ts to assert that calling an unknown URL (/api/this-does-not-exist) returns a status code of 404. 
Verified that npm test, npm run lint, and npm run format pass clean

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
