### PR TITLE
fix: order reviews by newest first

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -61,7 +61,7 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -71,7 +71,7 @@
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -87,7 +87,7 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
@@ -3964,7 +3964,7 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
       "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.3",
@@ -5217,7 +5217,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"

--- a/src/services/review.service.test.ts
+++ b/src/services/review.service.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest";
+import { prisma } from "../config/prisma";
+import { Review } from "../generated/prisma/client";
+import reviewService from "./review.service";
+
+describe("Review Service - findAllReviews", () => {
+  it("should return newest reviews first", async () => {
+    const mockReviews = [
+      {
+        id: "1",
+        createdAt: new Date("2026-01-02"),
+      },
+      {
+        id: "2",
+        createdAt: new Date("2026-01-01"),
+      },
+    ] as Review[];
+
+    vi.spyOn(prisma.review, "findMany").mockResolvedValue(mockReviews);
+
+    const reviews = await reviewService.findAllReviews();
+
+    expect(prisma.review.findMany).toHaveBeenCalledWith({
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    expect(reviews[0].createdAt.getTime()).toBeGreaterThan(
+      reviews[1].createdAt.getTime(),
+    );
+  });
+});

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -2,7 +2,7 @@ import { prisma } from "../config/prisma";
 import { Review } from "../generated/prisma/client";
 
 async function findAllReviews(): Promise<Review[]> {
-  return prisma.review.findMany({ orderBy: { createdAt: "asc" } });
+  return prisma.review.findMany({ orderBy: { createdAt: "desc" } });
 }
 
 async function findReviewById(id: string): Promise<Review | null> {


### PR DESCRIPTION
## Summary

This PR fixes the review ordering issue where older reviews appeared before newer ones.

## Changes made

- Updated `findAllReviews` to order reviews by `createdAt` descending.
- Added a test to verify that the newest reviews are returned first.

## Testing

The following checks were completed:

- npm test (passes)
- npm run lint (passes)
- npm run format (passes) 

Fixes #275

@ub-victor Could you please review this PR when you have time? Thank you.