### PR TITLE
docs: fix broken issue template links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,8 @@ If you add or change a route:
 
 Use the issue templates:
 
-- [Bug report](.github/ISSUE_TEMPLATE/bug_report.yml)
-- [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml)
+- [Bug report](.github/ISSUE_TEMPLATE/bug_report.md)
+- [Feature request](.github/ISSUE_TEMPLATE/feature_request.md)
 
 Search existing issues first to avoid duplicates.
 


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
This fixes the  two links in the `CONTRIBUTING.md`

From:
* `.github/ISSUE_TEMPLATE/bug_report.yml`
* `.github/ISSUE_TEMPLATE/feature_request.yml`

To:
* `.github/ISSUE_TEMPLATE/bug_report.md`
* `.github/ISSUE_TEMPLATE/feature_request.md`

<!-- 1-2 sentences describing your change. -->

## Related issue

Closes #291

## How did you test it?

<!-- Briefly: what you ran or clicked to confirm it works. -->

## Checklist

- [ ] My code builds (`npm run build`)
- [ ] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
