### PR TITLE
chore: remove duplicate keys in vitest.config.ts

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,6 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     globals: true,
     environment: "node",
-    include: ["src/**/*.test.ts"],
     setupFiles: ["./vitest.setup.ts"],
     exclude: ["dist/**", "node_modules/**"],
     coverage: {
@@ -13,6 +12,5 @@ export default defineConfig({
       reporter: ["text", "lcov"],
       exclude: ["src/generated/**", "dist/**", "vitest.setup.ts"],
     },
-    exclude: ["dist/**"],
   },
 });


### PR DESCRIPTION
## Summary
- Removes the duplicate `include` and `exclude` keys in `vitest.config.ts`; the second `exclude` was silently overriding the first, so `node_modules/**` was no longer excluded.

Fixes #282

## Test plan
- [x] `npm test` - 51/51 passing
- [x] `npm run lint` - clean