### PR TITLE
docs: add request/response payload examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,116 @@ Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 
 The interactive Swagger UI should be available at `http://localhost:3000/api/docs` once the server is running. The underlying spec lives at [`docs/openapi.yaml`](./docs/openapi.yaml). Admin-only endpoints require an `x-api-key` header matching `ADMIN_API_KEY`.
 
+### Quick examples
+
+All endpoints are prefixed with `/api` and return a consistent envelope:
+`{ "success": boolean, "message": string, "data": ... }`. Errors return
+`{ "success": false, "message": "...", "data": null }`.
+
+**`GET /api/events`** — list events (public, supports `?featured=true`)
+
+```json
+{
+  "success": true,
+  "message": "Events retrieved successfully",
+  "data": [
+    {
+      "id": "6f1c9d2e-8a4b-4c3d-9e2f-1a2b3c4d5e6f",
+      "title": "OSK Monthly Meetup",
+      "tagline": "Open source, together",
+      "imageUrl": "https://res.cloudinary.com/.../events/meetup.jpg",
+      "description": "Talks, demos, and networking for open source enthusiasts.",
+      "category": "meetup",
+      "mode": "in-person",
+      "featured": true,
+      "capacity": 100,
+      "registered": 42,
+      "date": "2026-09-12T17:00:00.000Z",
+      "endDate": null,
+      "timeLabel": "5:00 PM - 8:00 PM",
+      "location": "Norrsken House Kigali",
+      "speakers": ["Jane Doe"],
+      "registerUrl": "https://example.com/register",
+      "createdAt": "2026-08-01T09:00:00.000Z",
+      "updatedAt": "2026-08-01T09:00:00.000Z"
+    }
+  ]
+}
+```
+
+**`GET /api/projects`** — list projects (public)
+
+```json
+{
+  "success": true,
+  "message": "Projects retrieved successfully",
+  "data": [
+    {
+      "id": "0a1b2c3d-4e5f-6a7b-8c9d-0e1f2a3b4c5d",
+      "slug": "osk-backend",
+      "repoOwner": "Open-Source-Kigali",
+      "repoName": "osk-backend",
+      "imageUrl": "https://res.cloudinary.com/.../projects/osk-backend.png",
+      "tagline": "Backend for the OSK website",
+      "category": "web",
+      "status": "active",
+      "featured": true,
+      "maintainer": "Open Source Kigali",
+      "langColor": "#3178c6",
+      "ghDescription": "Backend for the official OSK website",
+      "ghLanguage": "TypeScript",
+      "ghTopics": ["nodejs", "express", "prisma"],
+      "ghStars": 12,
+      "ghForks": 34,
+      "ghOpenIssues": 5,
+      "ghContributors": 8,
+      "ghPullRequests": 3,
+      "ghPushedAt": "2026-08-05T14:30:00.000Z",
+      "lastFetchedAt": "2026-08-06T00:00:00.000Z",
+      "createdAt": "2026-07-01T10:00:00.000Z",
+      "updatedAt": "2026-08-06T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+**`POST /api/members`** — join as a member (public)
+
+Request:
+
+```json
+{
+  "name": "Jane Doe",
+  "email": "jane@example.com",
+  "githubUsername": "janedoe",
+  "orgName": "ALU",
+  "joinReason": "I want to contribute to open source projects in Kigali.",
+  "codingLevel": "intermediate"
+}
+```
+
+Response (`201 Created`):
+
+```json
+{
+  "success": true,
+  "message": "Member created successfully",
+  "data": {
+    "id": "9b8a7c6d-5e4f-3a2b-1c0d-9e8f7a6b5c4d",
+    "name": "Jane Doe",
+    "email": "jane@example.com",
+    "githubUsername": "janedoe",
+    "orgName": "ALU",
+    "joinReason": "I want to contribute to open source projects in Kigali.",
+    "codingLevel": "intermediate",
+    "createdAt": "2026-08-08T21:45:00.000Z",
+    "updatedAt": "2026-08-08T21:45:00.000Z"
+  }
+}
+```
+
+For the full list of endpoints, schemas, and admin operations, see the Swagger UI or [`docs/openapi.yaml`](./docs/openapi.yaml).
+
 ## Contributing
 
 Contributions are welcome. Please read [CONTRIBUTING.md](./CONTRIBUTING.md) for setup, branching, commit conventions, and the pull request flow. By participating, you agree to follow our [Code of Conduct](./CODE_OF_CONDUCT.md). To report a bug or request a feature, open an issue using one of the templates in [`.github/ISSUE_TEMPLATE`](./.github/ISSUE_TEMPLATE).


### PR DESCRIPTION
## What does this PR do?

Adds a "Quick examples" subsection to the API Documentation section of the README, with brief request/response payload examples for `GET /api/events`, `GET /api/projects`, and `POST /api/members`, plus a note on the shared `{ success, message, data }` response envelope.

## Related issue

Closes #258

## How did you test it?

The examples were derived directly from the source code (controllers, Zod schemas, `prisma/schema.prisma`, and `src/utils/response.ts`), so field names, messages, and status codes match the current implementation. Ran `npx prettier --check README.md` and it passes. Docs-only change — no code touched.

## Checklist

- [x] My code builds (`npm run build`) — docs-only change, no code touched
- [x] I added or updated tests and `npm test` passes — N/A, docs-only
- [ ] I updated `docs/openapi.yaml` if I changed any routes — N/A, no routes changed
- [ ] I added a Prisma migration if I changed `schema.prisma` — N/A
- [ ] I updated docs or `.env.example` if needed