### PR TITLE
fix: return unique contributor count in stats endpoint

### DIFF
--- a/src/services/stats.service.test.ts
+++ b/src/services/stats.service.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockReset } from "vitest-mock-extended";
+import type { DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "../generated/prisma/client";
+
+vi.mock("../config/prisma", async () => {
+  const { mockDeep } = await import("vitest-mock-extended");
+  return { prisma: mockDeep<PrismaClient>() };
+});
+
+vi.mock("./github.service", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./github.service")>();
+  return { ...actual, gh: vi.fn() };
+});
+
+import { prisma } from "../config/prisma";
+import statsService from "./stats.service";
+import { gh } from "./github.service";
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+const ghMock = vi.mocked(gh);
+
+// Minimal Response-like object: stats.service only reads `.json()`.
+const contributorsResponse = (logins: string[]): Response =>
+  ({
+    json: () => Promise.resolve(logins.map((login) => ({ login }))),
+  }) as Response;
+
+const mockTransaction = () =>
+  prismaMock.$transaction.mockResolvedValue([
+    120,
+    3,
+    2,
+    4,
+    5,
+    { _sum: { ghPullRequests: 42 } },
+  ]);
+
+beforeEach(() => {
+  mockReset(prismaMock);
+  ghMock.mockReset();
+});
+
+describe("getStats contributors count", () => {
+  it("counts each contributor once across all OSK repos", async () => {
+    mockTransaction();
+
+    ghMock
+      .mockResolvedValueOnce(contributorsResponse(["alice", "bob"]))
+      .mockResolvedValueOnce(contributorsResponse(["alice", "carol"]))
+      .mockResolvedValueOnce(contributorsResponse(["carol"]))
+      .mockResolvedValueOnce(contributorsResponse(["dave"]))
+      .mockResolvedValueOnce(contributorsResponse([]))
+      .mockResolvedValueOnce(contributorsResponse(["alice"]))
+      .mockResolvedValueOnce(contributorsResponse(["eve"]));
+
+    const stats = await statsService.getStats();
+
+    expect(ghMock).toHaveBeenCalledTimes(7);
+    expect(ghMock).toHaveBeenCalledWith(
+      "/repos/Open-Source-Kigali/osk-backend/contributors?per_page=100",
+    );
+    expect(stats.contributors).toBe(5);
+  });
+
+  it("skips repos whose GitHub call failed", async () => {
+    mockTransaction();
+
+    ghMock
+      .mockResolvedValueOnce(contributorsResponse(["alice", "bob"]))
+      .mockRejectedValueOnce(new Error("GitHub rate limit exceeded"))
+      .mockResolvedValueOnce(contributorsResponse(["alice", "carol"]))
+      .mockResolvedValueOnce(contributorsResponse(["carol"]))
+      .mockResolvedValueOnce(contributorsResponse(["dave"]))
+      .mockResolvedValueOnce(contributorsResponse(["dave"]))
+      .mockResolvedValueOnce(contributorsResponse(["eve"]));
+
+    const stats = await statsService.getStats();
+
+    expect(stats.contributors).toBe(5);
+  });
+
+  it("returns zero when every repo call fails", async () => {
+    mockTransaction();
+
+    ghMock.mockRejectedValue(new Error("GitHub rate limit exceeded"));
+
+    const stats = await statsService.getStats();
+
+    expect(stats.contributors).toBe(0);
+  });
+});
+
+describe("getStats database stats", () => {
+  it("returns members, projects, events, partners, reviews and pull requests from the transaction", async () => {
+    prismaMock.$transaction.mockResolvedValue([
+      150,
+      7,
+      3,
+      2,
+      6,
+      { _sum: { ghPullRequests: 24 } },
+    ]);
+
+    ghMock.mockResolvedValue(contributorsResponse(["alice"]));
+
+    const stats = await statsService.getStats();
+
+    expect(stats.members).toBe(300);
+    expect(stats.projects).toBe(7);
+    expect(stats.events).toBe(3);
+    expect(stats.partners).toBe(2);
+    expect(stats.reviews).toBe(6);
+    expect(stats.pullRequests).toBe(24);
+  });
+});

--- a/src/services/stats.service.ts
+++ b/src/services/stats.service.ts
@@ -28,7 +28,7 @@ async function getContributorsCount(): Promise<number> {
       result.value.forEach((c) => logins.add(c.login));
     }
   }
-  return results.length;
+  return logins.size;
 }
 
 async function getStats() {


### PR DESCRIPTION
## What does this PR do?

Fixes the stats endpoint always reporting exactly 7 contributors. `getContributorsCount` in `src/services/stats.service.ts` built a `Set` of unique contributor logins across all OSK repos, but returned `results.length` (the number of repos, which is 7) instead of `logins.size`.

Now contributors who appear in more than one repo are counted only once, so `GET /api/stats` reflects the real number of unique contributors.

## Related issue

Closes #277

## How did you test it?

- Added `src/services/stats.service.test.ts` with 4 unit tests covering:
  - unique-login deduplication across all 7 repos
  - skipping repos whose GitHub call fails (`Promise.allSettled`)
  - zero contributors when every repo call fails
  - the remaining stats flowing through from the DB transaction
- The GitHub calls are mocked via `vi.mock("./github.service")`, so tests need no internet or API token.
- `npm test` passes: 56 tests across 14 files (was 52/13 before).
- `npx tsc --noEmit`, `npx eslint .`, and `npx prettier --check .` all pass.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes (no route changes)
- [ ] I added a Prisma migration if I changed `schema.prisma` (no schema changes)
- [ ] I updated docs or `.env.example` if needed (not needed)