### PR TITLE
feat: filter out bot accounts from contributors count

### DIFF
--- a/src/services/stats.service.test.ts
+++ b/src/services/stats.service.test.ts
@@ -89,6 +89,25 @@ describe("getStats contributors count", () => {
 
     expect(stats.contributors).toBe(0);
   });
+
+  it("excludes bot accounts ending with [bot]", async () => {
+    mockTransaction();
+
+    ghMock
+      .mockResolvedValueOnce(
+        contributorsResponse(["alice", "github-actions[bot]", "bob"]),
+      )
+      .mockResolvedValueOnce(contributorsResponse(["dependabot[bot]"]))
+      .mockResolvedValueOnce(contributorsResponse(["alice"]))
+      .mockResolvedValueOnce(contributorsResponse([]))
+      .mockResolvedValueOnce(contributorsResponse(["renovate[bot]"]))
+      .mockResolvedValueOnce(contributorsResponse(["carol"]))
+      .mockResolvedValueOnce(contributorsResponse(["alice"]));
+
+    const stats = await statsService.getStats();
+
+    expect(stats.contributors).toBe(3);
+  });
 });
 
 describe("getStats database stats", () => {

--- a/src/services/stats.service.ts
+++ b/src/services/stats.service.ts
@@ -13,6 +13,8 @@ const OSK_REPOS = [
 
 const MEMBERS_OFFSET = 150;
 
+const BOT_SUFFIX = "[bot]";
+
 async function getContributorsCount(): Promise<number> {
   const results = await Promise.allSettled(
     OSK_REPOS.map((repo) =>
@@ -25,7 +27,9 @@ async function getContributorsCount(): Promise<number> {
   const logins = new Set<string>();
   for (const result of results) {
     if (result.status === "fulfilled" && Array.isArray(result.value)) {
-      result.value.forEach((c) => logins.add(c.login));
+      result.value.forEach((c) => {
+        if (!c.login.endsWith(BOT_SUFFIX)) logins.add(c.login);
+      });
     }
   }
   return logins.size;


### PR DESCRIPTION
## What does this PR do?

`getContributorsCount` in `src/services/stats.service.ts` counts every unique contributor login returned by the GitHub API, including automation accounts such as `github-actions[bot]` and `dependabot[bot]`. These bots are not humans and inflate the contributor number shown on the website.

This change skips any login ending in `[bot]`, so only human contributors are counted. It builds directly on the merged fix for #277 (PR #311), which made the count deduplicate correctly.

## Related issue

Closes #254

## How did you test it?

- Added a test case to `src/services/stats.service.test.ts` that mixes bot logins (`github-actions[bot]`, `dependabot[bot]`, `renovate[bot]`) with real users across repos and verifies only humans are counted.
- All GitHub calls are mocked via `vi.mock("./github.service")` — no network needed.
- `npm test` passes: 60 tests across 15 files (was 56/14 before this PR).
- `npx tsc --noEmit`, `npx eslint .`, and `npx prettier --check .` all pass.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes (no route changes)
- [ ] I added a Prisma migration if I changed `schema.prisma` (no schema changes)
- [ ] I updated docs or `.env.example` if needed (not needed)