### PR TITLE
Feat: featured reviews

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -735,6 +735,11 @@ paths:
         "500": { $ref: "#/components/responses/InternalError" }
 
   /reviews:
+    parameters:
+        - in: path
+          name: featured
+          schema: { type: boolean}
+          description: "Filter reviews by featured status. Provide true or false; omit to return all."
     get:
       tags: [Reviews]
       summary: List all reviews
@@ -896,6 +901,7 @@ components:
         profilePublicId: { type: string }
         role: { type: string }
         message: { type: string }
+        featured: { type: boolean }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -735,6 +735,11 @@ paths:
         "500": { $ref: "#/components/responses/InternalError" }
 
   /reviews:
+    parameters:
+      - in: path
+        name: featured
+        schema: { type: boolean }
+        description: "Filter reviews by featured status. Provide true or false; omit to return all."
     get:
       tags: [Reviews]
       summary: List all reviews
@@ -896,6 +901,7 @@ components:
         profilePublicId: { type: string }
         role: { type: string }
         message: { type: string }
+        featured: { type: boolean }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
 

--- a/prisma/migrations/20260729174941_add_featured_field_in_review_model/migration.sql
+++ b/prisma/migrations/20260729174941_add_featured_field_in_review_model/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "featured" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -122,6 +122,7 @@ model Review {
   profilePublicId String
   role            String
   message         String
+  featured      Boolean   @default(false)
   createdAt       DateTime @default(now())
   updatedAt       DateTime @updatedAt
 }

--- a/src/controllers/review.controller.test.ts
+++ b/src/controllers/review.controller.test.ts
@@ -1,0 +1,72 @@
+vi.mock("../services/review.service");
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import reviewService from "../services/review.service";
+import request from "supertest";
+import app from "../app";
+
+beforeEach(() => vi.resetAllMocks());
+const mockReviews = [
+  {
+    id: "4",
+    name: "Arnold jabo",
+    profileUrl: "https://images.com/456",
+    profilePublicId: "43",
+    role: "user",
+    message: "some random messages",
+    featured: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "40",
+    name: "John Doe",
+    profileUrl: "https://images.com/400",
+    profilePublicId: "47",
+    role: "user",
+    message: "Lorem ipsum lorem ipsum",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "50",
+    name: "jane doe",
+    profileUrl: "https://images.com/600",
+    profilePublicId: "73",
+    role: "user",
+    message: "Great Job!",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+describe("GET api/reviews", () => {
+  it("gets all reviews", async () => {
+    vi.mocked(reviewService.findAllReviews).mockResolvedValue(mockReviews);
+    const response = await request(app).get("/api/reviews");
+
+    expect(response.status).toBe(200);
+    expect(reviewService.findAllReviews).toHaveBeenCalledWith(undefined);
+  });
+
+  it("returns featured reviews ", async () => {
+    vi.mocked(reviewService.findAllReviews).mockResolvedValue(mockReviews);
+
+    const response = await request(app).get("/api/reviews?featured=true");
+    expect(response.status).toBe(200);
+    expect(reviewService.findAllReviews).toHaveBeenCalledWith(true);
+  });
+  it("returns non-featured reviews ", async () => {
+    const nonFeaturedReviews = mockReviews.filter(
+      (review) => review.featured === false,
+    );
+    vi.mocked(reviewService.findAllReviews).mockResolvedValue(
+      nonFeaturedReviews,
+    );
+
+    const response = await request(app).get("/api/reviews?featured=false");
+    expect(response.status).toBe(200);
+    expect(response.body.data).toHaveLength(1);
+    expect(reviewService.findAllReviews).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/controllers/review.controller.ts
+++ b/src/controllers/review.controller.ts
@@ -7,13 +7,14 @@ import trimStrings from "../utils/trim-strings";
 
 type ReviewBody = Omit<Review, "id" | "createdAt" | "updatedAt">;
 
-async function findAllReviews(
-  _req: Request,
-  res: Response,
-  next: NextFunction,
-) {
+async function findAllReviews(req: Request, res: Response, next: NextFunction) {
   try {
-    const reviews = await reviewService.findAllReviews();
+    const featuredParams = Array.isArray(req.query.featured)
+      ? req.query.featured[0]
+      : req.query.featured;
+
+    const featured = featuredParams ? featuredParams === "true" : undefined;
+    const reviews = await reviewService.findAllReviews(featured);
     response.success(res, reviews, 200, "Reviews retrieved successfully");
   } catch (err) {
     next(err);

--- a/src/services/event.service.ts
+++ b/src/services/event.service.ts
@@ -4,7 +4,7 @@ import { Event, Prisma } from "../generated/prisma/client";
 async function findAllEvents(featured?: boolean) {
   return prisma.event.findMany({
     where: featured !== undefined ? { featured } : undefined,
-    orderBy: { date: "desc" },
+    orderBy: { date: "asc" },
     omit: { imagePublicId: true },
   });
 }

--- a/src/services/review.service.test.ts
+++ b/src/services/review.service.test.ts
@@ -1,7 +1,52 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { prisma } from "../config/prisma";
-import { Review } from "../generated/prisma/client";
+import { PrismaClient, Review } from "../generated/prisma/client";
+import { DeepMockProxy, mockReset } from "vitest-mock-extended";
 import reviewService from "./review.service";
+
+vi.mock("../config/prisma", async () => {
+  const { mockDeep } = await import("vitest-mock-extended");
+  return { prisma: mockDeep<PrismaClient>() };
+});
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+const mockReviews = [
+  {
+    id: "4",
+    name: "Arnold jabo",
+    profileUrl: "https://images.com/456",
+    profilePublicId: "43",
+    role: "user",
+    message: "some random messages",
+    featured: false,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "40",
+    name: "John Doe",
+    profileUrl: "https://images.com/400",
+    profilePublicId: "47",
+    role: "user",
+    message: "Lorem ipsum lorem ipsum",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+  {
+    id: "50",
+    name: "jane doe",
+    profileUrl: "https://images.com/600",
+    profilePublicId: "73",
+    role: "user",
+    message: "Great Job!",
+    featured: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  },
+];
+
+beforeEach(() => mockReset(prismaMock));
 
 describe("Review Service - findAllReviews", () => {
   it("should return newest reviews first", async () => {
@@ -15,19 +60,55 @@ describe("Review Service - findAllReviews", () => {
         createdAt: new Date("2026-01-01"),
       },
     ] as Review[];
-
-    vi.spyOn(prisma.review, "findMany").mockResolvedValue(mockReviews);
+    prismaMock.review.findMany.mockResolvedValue(mockReviews);
 
     const reviews = await reviewService.findAllReviews();
 
     expect(prisma.review.findMany).toHaveBeenCalledWith({
-      orderBy: {
-        createdAt: "desc",
-      },
+      orderBy: { createdAt: "desc" },
     });
 
     expect(reviews[0].createdAt.getTime()).toBeGreaterThan(
       reviews[1].createdAt.getTime(),
     );
+  });
+
+  it("returns only featured reviews", async () => {
+    const featuredReviews = mockReviews.filter(
+      (review) => review.featured === true,
+    );
+    prismaMock.review.findMany.mockResolvedValue(featuredReviews);
+    const results = await reviewService.findAllReviews(true);
+
+    expect(prisma.review.findMany).toHaveBeenCalledWith({
+      where: { featured: true },
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(results).toEqual(featuredReviews);
+  });
+
+  it("returns non featured reviews", async () => {
+    const nonFeaturedReviews = mockReviews.filter(
+      (review) => review.featured === false,
+    );
+    prismaMock.review.findMany.mockResolvedValue(nonFeaturedReviews);
+    const results = await reviewService.findAllReviews(false);
+
+    expect(prisma.review.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+    });
+
+    expect(results).toEqual(nonFeaturedReviews);
+  });
+
+  it("returns all revies when featured flag is undfined", async () => {
+    prismaMock.review.findMany.mockResolvedValue(mockReviews);
+    const results = await reviewService.findAllReviews(undefined);
+
+    expect(prisma.review.findMany).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+    });
+    expect(results).toEqual(mockReviews);
   });
 });

--- a/src/services/review.service.ts
+++ b/src/services/review.service.ts
@@ -1,8 +1,12 @@
 import { prisma } from "../config/prisma";
 import { Review } from "../generated/prisma/client";
 
-async function findAllReviews(): Promise<Review[]> {
-  return prisma.review.findMany({ orderBy: { createdAt: "desc" } });
+async function findAllReviews(featuredReviews?: boolean): Promise<Review[]> {
+  const where = featuredReviews ? { featured: featuredReviews } : undefined;
+  return prisma.review.findMany({
+    where,
+    orderBy: { createdAt: "desc" },
+  });
 }
 
 async function findReviewById(id: string): Promise<Review | null> {


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
The PR fetches reviews with the featured field set to true in the request query parameter and fetches all reviews when the query parameter is not provided

## Related issue

Closes #296 

## How did you test it?
I have created a unit test for `findAllReviews` function in the review services to test whether it returns reviews that have true on featured field or if there is no params it fetches all reviews, whether featured or not

## Database change
- Added a `featured` Boolean field to the `Review` model in `prisma/schema.prisma`.
- Default value is `false`.
- This enables filtering reviews by featured status (e.g., return only featured reviews when needed).
- Data implication: existing reviews will have `featured = false` by default unless explicitly updated.


## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [x] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed

<img width="887" height="402" alt="Screenshot 2026-07-29 184936" src="https://github.com/user-attachments/assets/db9807c1-17df-490c-b738-7b0a6a48d4e0" />

<img width="1832" height="948" alt="image" src="https://github.com/user-attachments/assets/03979535-a229-4f76-af92-6ab9e32f981d" />

