### PR TITLE
validate endDate is chronologically after date in event schema

### DIFF
--- a/src/schemas/event.schema.test.ts
+++ b/src/schemas/event.schema.test.ts
@@ -1,0 +1,79 @@
+import { createEventSchema, updateEventSchema } from "./event.schema";
+import { describe, it, expect } from "vitest";
+describe("event.schema date range validation", () => {
+  const baseEvent = {
+    title: "Tech Summit",
+    description: "Annual tech conference",
+    category: "Technology",
+    location: "Main Auditorium",
+    date: "2026-09-01T10:00:00Z",
+  };
+
+  describe("createEventSchema", () => {
+    it("should reject when endDate is earlier than start date", () => {
+      const result = createEventSchema.safeParse({
+        ...baseEvent,
+        date: "2026-09-01T10:00:00Z",
+        endDate: "2026-08-31T10:00:00Z",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.path.includes("endDate"),
+        );
+        expect(issue?.message).toBe(
+          "End date must be on or after the start date",
+        );
+      }
+    });
+
+    it("should accept when endDate is equal to or after start date", () => {
+      const sameDate = createEventSchema.safeParse({
+        ...baseEvent,
+        date: "2026-09-01T10:00:00Z",
+        endDate: "2026-09-01T10:00:00Z",
+      });
+
+      const afterDate = createEventSchema.safeParse({
+        ...baseEvent,
+        date: "2026-09-01T10:00:00Z",
+        endDate: "2026-09-02T10:00:00Z",
+      });
+
+      expect(sameDate.success).toBe(true);
+      expect(afterDate.success).toBe(true);
+    });
+
+    it("should accept when endDate is null or omitted", () => {
+      const resultNull = createEventSchema.safeParse({
+        ...baseEvent,
+        endDate: null,
+      });
+
+      const resultOmitted = createEventSchema.safeParse(baseEvent);
+
+      expect(resultNull.success).toBe(true);
+      expect(resultOmitted.success).toBe(true);
+    });
+  });
+
+  describe("updateEventSchema", () => {
+    it("should reject when endDate is earlier than start date", () => {
+      const result = updateEventSchema.safeParse({
+        date: "2026-09-01T10:00:00Z",
+        endDate: "2026-08-31T10:00:00Z",
+      });
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.path.includes("endDate"),
+        );
+        expect(issue?.message).toBe(
+          "End date must be on or after the start date",
+        );
+      }
+    });
+  });
+});

--- a/src/schemas/event.schema.ts
+++ b/src/schemas/event.schema.ts
@@ -1,5 +1,23 @@
 import { z } from "zod";
 
+const validateDateRange = (data: {
+  date?: Date | null;
+  endDate?: Date | null;
+}) => {
+  if (!data.date || !data.endDate) {
+    return true;
+  }
+  if (isNaN(data.date.getTime()) || isNaN(data.endDate.getTime())) {
+    return true;
+  }
+  return data.endDate.getTime() >= data.date.getTime();
+};
+
+const dateRangeRefine = {
+  message: "End date must be on or after the start date",
+  path: ["endDate"],
+};
+
 const eventBaseSchema = z.object({
   title: z.string().min(1, "Title is required").trim(),
   tagline: z.string().trim().optional().nullable(),
@@ -75,21 +93,23 @@ const eventBaseSchema = z.object({
   registerUrl: z.string().trim().optional().nullable(),
 });
 
-export const createEventSchema = eventBaseSchema.refine(
-  (data) => {
-    if (
-      typeof data.capacity === "number" &&
-      typeof data.registered === "number"
-    ) {
-      return data.capacity >= data.registered;
-    }
-    return true;
-  },
-  {
-    message: "Registered count cannot exceed capacity",
-    path: ["registered"],
-  },
-);
+export const createEventSchema = eventBaseSchema
+  .refine(
+    (data) => {
+      if (
+        typeof data.capacity === "number" &&
+        typeof data.registered === "number"
+      ) {
+        return data.capacity >= data.registered;
+      }
+      return true;
+    },
+    {
+      message: "Registered count cannot exceed capacity",
+      path: ["registered"],
+    },
+  )
+  .refine(validateDateRange, dateRangeRefine);
 
 export const updateEventSchema = eventBaseSchema
   .omit({ mode: true, featured: true, speakers: true })
@@ -123,7 +143,8 @@ export const updateEventSchema = eventBaseSchema
           .map((s) => s.trim())
           .filter(Boolean);
       }),
-  });
+  })
+  .refine(validateDateRange, dateRangeRefine);
 
 export type CreateEventInput = z.infer<typeof createEventSchema>;
 export type UpdateEventInput = z.infer<typeof updateEventSchema>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["vitest/globals"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
<!-- Thanks for contributing! Keep PRs small and focused. -->

## What does this PR do?
Adds cross-field validation to "createEventSchema" and "updateEventSchema" using Zod refinements to ensure "endDate" is chronologically on or after "date".

## Related issue

Closes #248 

## How did you test it?

Added schema unit tests in `src/schemas/event.schema.test.ts` and verified with `npm test` and `tsc --noEmit`.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [ ] I updated `docs/openapi.yaml` if I changed any routes
- [ ] I added a Prisma migration if I changed `schema.prisma`
- [ ] I updated docs or `.env.example` if needed
