### PR TITLE
docs: add kawacukennedy to contributors list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,3 +5,4 @@ Everyone listed here appears on the Open Source Kigali website. To add yourself,
 <!-- Add your GitHub username below, one per line -->
 
 Nick-Lemy
+kawacukennedy


### PR DESCRIPTION
## What does this PR do?

Adds `kawacukennedy` to `CONTRIBUTORS.md` so the username appears on the Open Source Kigali website contributors section, as described in the README. The change is a single line addition:

```
Nick-Lemy
kawacukennedy
```

## Related issue

Closes #338

## How did you test it?

- The format matches the documented convention (one GitHub username per line, no spaces).
- The `GET /api/contributors` endpoint reads this file and fetches each username public GitHub profile.
- No code, routes, or schema changes.

## Checklist

- [x] No code changes, so build/tests unaffected
- [x] Updated `CONTRIBUTORS.md`