### PR TITLE
test: add unit tests for the event service

### DIFF
--- a/src/services/event.service.test.ts
+++ b/src/services/event.service.test.ts
@@ -35,11 +35,13 @@ const mockEvent = {
   updatedAt: new Date(),
 };
 
+const { imagePublicId: _imagePublicId, ...mockPublicEvent } = mockEvent;
+
 beforeEach(() => mockReset(prismaMock));
 
 describe("findAllEvents", () => {
   it("returns all events when no featured filter is given", async () => {
-    prismaMock.event.findMany.mockResolvedValue([mockEvent]);
+    prismaMock.event.findMany.mockResolvedValue([mockPublicEvent] as never);
 
     const result = await eventService.findAllEvents();
 
@@ -48,11 +50,11 @@ describe("findAllEvents", () => {
       orderBy: { date: "asc" },
       omit: { imagePublicId: true },
     });
-    expect(result).toEqual([mockEvent]);
+    expect(result).toEqual([mockPublicEvent]);
   });
 
   it("returns only featured events when featured is true", async () => {
-    prismaMock.event.findMany.mockResolvedValue([mockEvent]);
+    prismaMock.event.findMany.mockResolvedValue([mockPublicEvent] as never);
 
     const result = await eventService.findAllEvents(true);
 
@@ -61,7 +63,7 @@ describe("findAllEvents", () => {
       orderBy: { date: "asc" },
       omit: { imagePublicId: true },
     });
-    expect(result).toEqual([mockEvent]);
+    expect(result).toEqual([mockPublicEvent]);
   });
 
   it("returns an empty list when no events match", async () => {
@@ -80,7 +82,7 @@ describe("findAllEvents", () => {
 
 describe("findEventById", () => {
   it("returns the event when found, omitting imagePublicId", async () => {
-    prismaMock.event.findUnique.mockResolvedValue(mockEvent);
+    prismaMock.event.findUnique.mockResolvedValue(mockPublicEvent as never);
 
     const result = await eventService.findEventById("1");
 
@@ -88,7 +90,7 @@ describe("findEventById", () => {
       where: { id: "1" },
       omit: { imagePublicId: true },
     });
-    expect(result).toEqual(mockEvent);
+    expect(result).toEqual(mockPublicEvent);
   });
 
   it("returns null when not found", async () => {

--- a/src/services/event.service.test.ts
+++ b/src/services/event.service.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mockReset } from "vitest-mock-extended";
+import type { DeepMockProxy } from "vitest-mock-extended";
+import type { PrismaClient } from "../generated/prisma/client";
+
+vi.mock("../config/prisma", async () => {
+  const { mockDeep } = await import("vitest-mock-extended");
+  return { prisma: mockDeep<PrismaClient>() };
+});
+
+import { prisma } from "../config/prisma";
+import eventService from "./event.service";
+
+const prismaMock = prisma as DeepMockProxy<PrismaClient>;
+
+const mockEvent = {
+  id: "1",
+  title: "OSK Meetup",
+  tagline: "Community event",
+  imageUrl: "https://example.com/image.jpg",
+  imagePublicId: "abc123",
+  description: "An open-source meetup",
+  category: "community",
+  mode: "in-person",
+  featured: true,
+  capacity: 100,
+  registered: 30,
+  date: new Date(),
+  endDate: new Date(),
+  timeLabel: "10:00 AM",
+  location: "Kigali",
+  speakers: ["Alice"],
+  registerUrl: "https://example.com/register",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => mockReset(prismaMock));
+
+describe("findAllEvents", () => {
+  it("returns all events when no featured filter is given", async () => {
+    prismaMock.event.findMany.mockResolvedValue([mockEvent]);
+
+    const result = await eventService.findAllEvents();
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith({
+      where: undefined,
+      orderBy: { date: "asc" },
+      omit: { imagePublicId: true },
+    });
+    expect(result).toEqual([mockEvent]);
+  });
+
+  it("returns only featured events when featured is true", async () => {
+    prismaMock.event.findMany.mockResolvedValue([mockEvent]);
+
+    const result = await eventService.findAllEvents(true);
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith({
+      where: { featured: true },
+      orderBy: { date: "asc" },
+      omit: { imagePublicId: true },
+    });
+    expect(result).toEqual([mockEvent]);
+  });
+
+  it("returns an empty list when no events match", async () => {
+    prismaMock.event.findMany.mockResolvedValue([]);
+
+    const result = await eventService.findAllEvents(true);
+
+    expect(prismaMock.event.findMany).toHaveBeenCalledWith({
+      where: { featured: true },
+      orderBy: { date: "asc" },
+      omit: { imagePublicId: true },
+    });
+    expect(result).toEqual([]);
+  });
+});
+
+describe("findEventById", () => {
+  it("returns the event when found, omitting imagePublicId", async () => {
+    prismaMock.event.findUnique.mockResolvedValue(mockEvent);
+
+    const result = await eventService.findEventById("1");
+
+    expect(prismaMock.event.findUnique).toHaveBeenCalledWith({
+      where: { id: "1" },
+      omit: { imagePublicId: true },
+    });
+    expect(result).toEqual(mockEvent);
+  });
+
+  it("returns null when not found", async () => {
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    const result = await eventService.findEventById("nonexistent");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("findEventByIdInternal", () => {
+  it("returns the event when found, without omitting imagePublicId", async () => {
+    prismaMock.event.findUnique.mockResolvedValue(mockEvent);
+
+    const result = await eventService.findEventByIdInternal("1");
+
+    expect(prismaMock.event.findUnique).toHaveBeenCalledWith({
+      where: { id: "1" },
+    });
+    expect(result).toEqual(mockEvent);
+  });
+
+  it("returns null when not found", async () => {
+    prismaMock.event.findUnique.mockResolvedValue(null);
+
+    const result = await eventService.findEventByIdInternal("nonexistent");
+
+    expect(result).toBeNull();
+  });
+});
+
+describe("addEvent", () => {
+  it("creates and returns a new event", async () => {
+    prismaMock.event.create.mockResolvedValue(mockEvent);
+    const {
+      id: _id,
+      createdAt: _createdAt,
+      updatedAt: _updatedAt,
+      ...input
+    } = mockEvent;
+
+    const result = await eventService.addEvent(input);
+
+    expect(prismaMock.event.create).toHaveBeenCalledWith({ data: input });
+    expect(result).toEqual(mockEvent);
+  });
+});
+
+describe("updateEvent", () => {
+  it("updates and returns the event", async () => {
+    const updated = { ...mockEvent, title: "OSK Hackathon" };
+    prismaMock.event.update.mockResolvedValue(updated);
+
+    const result = await eventService.updateEvent("1", {
+      title: "OSK Hackathon",
+    });
+
+    expect(prismaMock.event.update).toHaveBeenCalledWith({
+      where: { id: "1" },
+      data: { title: "OSK Hackathon" },
+    });
+    expect(result).toEqual(updated);
+  });
+});
+
+describe("deleteEvent", () => {
+  it("deletes the event by id", async () => {
+    prismaMock.event.delete.mockResolvedValue(mockEvent);
+
+    await eventService.deleteEvent("1");
+
+    expect(prismaMock.event.delete).toHaveBeenCalledWith({
+      where: { id: "1" },
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds `src/services/event.service.test.ts`, covering all six functions in `event.service.ts` (findAllEvents, addEvent, findEventById, findEventByIdInternal, updateEvent, deleteEvent). Tests replace the database with a mocked Prisma client per the pattern in `member.service.test.ts`, so they run without Postgres.

## Related issue

Closes #285

## How did you test it?

- `npm test` — all 70 tests pass (16 test files), including the 10 new ones.
- `npm run lint` — clean.
- `npx prettier --write src/services/event.service.test.ts` — no changes needed (repo-wide `npm run format` only rewrites CRLF→LF line endings on this Windows checkout, so I formatted only this file to keep the diff focused).
- `npx tsc --noEmit` — clean.

## Checklist

- [x] My code builds (`npm run build`)
- [x] I added or updated tests and `npm test` passes
- [x] I updated `docs/openapi.yaml` if I changed any routes
- [x] I added a Prisma migration if I changed `schema.prisma`
- [x] I updated docs or `.env.example` if needed

Note: only `src/services/event.service.test.ts` was added; the service code itself is unchanged.